### PR TITLE
Align 3D skin abstractions with unified render contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,107 @@
+# AGENTS.md
+
+## Purpose
+
+AutoEnv should generate and evaluate environments that share one core game logic while supporting multiple presentation modalities:
+- Text environments for LLM policy learning.
+- 2D visual environments for image-based interaction.
+- 3D visual environments for richer embodied interaction.
+
+This document defines the current architecture, explains how 3D is built in PR #8, and sets the abstraction contract to align text/2D/3D under one model.
+
+## Current Code Architecture
+
+Core runtime is split into three layers.
+
+1. Environment semantics (`base/env`)
+- `BaseEnv`: true state, transition, reward.
+- `ObsEnv`: semantic observation extraction (`observe_semantic`).
+- `SkinEnv`: skin rendering over semantic observations.
+
+2. Solver/runtime (`base/agent`, `benchmarks/base`)
+- Solver consumes skin output as agent observation.
+- Benchmark runner dynamically loads each env and executes solver loop.
+
+3. Generation pipelines (`autoenv/pipeline`)
+- `GeneratorPipeline`: environment code/config/levels.
+- `VisualPipeline`: visual assets and runnable visual scene.
+
+## How 3D Is Built Today
+
+`VisualPipeline.create_default(dimension="3d")` builds the DAG:
+
+`Analyzer -> Strategist -> AssetGenerator -> BackgroundRemoval -> Image3DConvert -> ThreeJSAssembly`
+
+Node responsibilities:
+- `AnalyzerNode`: parse benchmark/instruction and write `analysis.json`.
+- `StrategistNode`: produce `strategy.json` with asset plan.
+- `AssetGeneratorNode`: generate style-consistent 2D assets.
+- `BackgroundRemovalNode`: remove background/crop for cleaner conversion.
+- `Image3DConvertNode`: call Meshy image-to-3D, poll progress, download `.glb` to `models_3d/`.
+- `ThreeJSAssemblyNode`: build `game/index.html`, copy models to `game/models/`, optionally ask agent to enhance JS logic.
+
+Current 3D output is a scene runtime (`index.html + models/*.glb`) and not yet a canonical environment runtime with the same authority as `transition/reward` in Python env classes.
+
+## Alignment Problem
+
+Without a shared contract, text/2D/3D can diverge:
+- Agent input format differs by modality.
+- Human display and agent display are not explicitly separated.
+- Visual pipeline artifacts are not normalized for upstream orchestrators.
+- 3D scene logic can drift away from canonical state transition rules.
+
+## Aligned Abstraction (Adopted)
+
+### 1) Unified skin output contract
+
+`base/env/skin_output.py` introduces `SkinRenderOutput`:
+- `agent_view`: what solver receives.
+- `human_view`: optional richer UI view.
+- `modality`: `text | 2d | 3d | multi`.
+- `artifacts`: paths/handles for render assets.
+- `metadata`: auxiliary render metadata.
+
+`SkinEnv.render()` now normalizes output to this contract while keeping backward compatibility with existing `render_skin()` implementations.
+
+### 2) Backward-compatible solver behavior
+
+Both solver implementations (`base/agent/base_solver.py`, `benchmarks/base/agent.py`) now:
+- Prefer `env.render(...)` when present.
+- Fallback to legacy `render_skin(...)` behavior.
+- Read observation from `info["agent_obs"]` first, then fallback to `info["skinned"]`.
+
+This keeps all existing benchmark envs runnable while enabling richer modality outputs.
+
+### 3) Unified visual artifact manifest
+
+`AutoEnvContext` now carries `skin_manifest`.
+- 2D `AssemblyNode` sets manifest with game entrypoint and assets dir.
+- 3D `ThreeJSAssemblyNode` sets manifest with HTML entrypoint and models dir.
+
+This gives upper layers a single way to consume generated skins regardless of modality.
+
+## Canonical Rule For Future Work
+
+- `transition()` and `reward()` remain the only source of environment truth.
+- All modalities are projections of semantic state, not separate game authorities.
+- Visual code (pygame/three.js) should be treated as view/runtime adapters unless intentionally promoted to core env logic.
+
+## Recommended Next Steps
+
+1. Add a `TextAssemblyNode` that emits the same `skin_manifest` contract for text-only runs.
+2. Add consistency tests:
+- same action sequence over same seed,
+- text/2D/3D should produce identical semantic state traces and reward traces.
+3. Move three.js enhancement prompts toward generated view adapters, not independent game rule engines.
+4. Define versioned schema for `skin_manifest` to stabilize downstream tooling.
+
+## Practical Usage Pattern
+
+When adding a new modality:
+
+1. Keep semantic env unchanged (`BaseEnv/ObsEnv`).
+2. Implement renderer adapter that returns `SkinRenderOutput`.
+3. Ensure generation pipeline writes `skin_manifest` with a valid entrypoint.
+4. Validate semantic consistency against text baseline.
+
+This keeps AutoEnv extensible without modality-specific logic forks.

--- a/IMPLEMENTATION_3D.md
+++ b/IMPLEMENTATION_3D.md
@@ -1,0 +1,199 @@
+# 3D 场景生成 - 实现说明
+
+## 实现内容
+
+### 1. 新增节点：ThreeJSAssemblyNode
+
+**位置**: `autoenv/pipeline/visual/nodes.py`
+
+**功能**:
+
+- 替代 3D 模式下的 AssemblyNode (2D 用 pygame，3D 用 three.js)
+- 从 three.js 模板生成可交互 HTML 场景
+- 自动生成模型加载、定位、动画代码
+- 可选 agent 增强（添加游戏逻辑）
+
+**核心方法**:
+
+```python
+_generate_threejs_scene()  # 生成HTML文件
+_generate_positioning_code()  # 模型定位逻辑（圆形布局）
+_generate_animation_code()  # 简单旋转动画
+_build_enhancement_prompt()  # Agent提示（可选）
+```
+
+### 2. Three.js 模板
+
+**位置**: `autoenv/pipeline/visual/threejs_template.html`
+
+**特性**:
+
+- 使用 three.js CDN (v0.170.0)
+- OrbitControls (鼠标控制相机)
+- GLTFLoader (加载.glb 模型)
+- 完整光照系统 (环境光 + 方向光 + 阴影)
+- 地面平面 + 网格辅助
+- 键盘 WASD 移动
+- 加载进度提示
+
+**可替换占位符**:
+
+- `{MODEL_COUNT}`: 模型数量
+- `{MODEL_PATHS_JSON}`: 模型路径映射
+- `{MODEL_POSITIONING_CODE}`: JS 定位代码
+- `{ANIMATION_CODE}`: JS 动画代码
+
+### 3. Pipeline 更新
+
+**位置**: `autoenv/pipeline/visual/pipeline.py`
+
+**变更**:
+
+```python
+# 2D模式 (dimension="2d")
+Analyzer → Strategist → AssetGenerator → BackgroundRemoval → AssemblyNode (pygame)
+
+# 3D模式 (dimension="3d")
+Analyzer → Strategist → AssetGenerator → BackgroundRemoval → Image3DConvert → ThreeJSAssemblyNode (three.js)
+```
+
+**新增 agent**: `threejs_agent` (step_limit=60, cost_limit=12.0)
+
+## 功能对比分析
+
+### 2D Assembly (Pygame)
+
+| 方面 | 实现                  |
+| ---- | --------------------- |
+| 输出 | game.py (Python 脚本) |
+| 资源 | .png 图片             |
+| 渲染 | 2D sprite blitting    |
+| 运行 | `python game.py`      |
+| 交互 | 键盘/鼠标事件         |
+| 物理 | 简单 2D 碰撞          |
+
+### 3D Assembly (Three.js)
+
+| 方面 | 实现                    |
+| ---- | ----------------------- |
+| 输出 | index.html (Web 应用)   |
+| 资源 | .glb 3D 模型            |
+| 渲染 | WebGL (GPU 加速)        |
+| 运行 | 浏览器 / HTTP 服务器    |
+| 交互 | 轨道控制器 + 键盘       |
+| 物理 | 可集成 Rapier/Cannon.js |
+
+## 验证方法
+
+### 1. 运行 3D 生成
+
+```python
+# test_3d_generation.py
+from pathlib import Path
+from autoenv.pipeline.visual.pipeline import VisualPipeline
+
+async def main():
+    pipeline = VisualPipeline.create_default(
+        image_model="gemini-2.5-flash-image",
+        dimension="3d",
+        meshy_api_key="msy_vfeMrK0HGYuJir4zK74nfEz2ddn5mNYUrzdU",
+        max_3d_assets=3
+    )
+
+    await pipeline.run(
+        instruction="A 3D puzzle game with boxes and a player",
+        output_dir=Path("workspace/test_3d")
+    )
+
+import asyncio
+asyncio.run(main())
+```
+
+### 2. 查看生成结果
+
+```bash
+cd workspace/test_3d/game
+python -m http.server 8000
+# 浏览器打开: http://localhost:8000
+```
+
+### 3. 验证项
+
+- [ ] HTML 文件包含所有模型路径
+- [ ] 模型正确加载并显示
+- [ ] 相机控制正常工作
+- [ ] 光照和阴影正确
+- [ ] 模型位置合理分布
+- [ ] 动画流畅运行
+
+## 与 2D Assembly 的一致性
+
+### 相同点
+
+1. **输入**: 都依赖 strategy.json 和 generated_assets
+2. **流程**: Analyzer → Strategist → AssetGenerator → BackgroundRemoval → Assembly
+3. **输出结构**: game/目录 + 资源子目录
+4. **可运行**: 都生成完整可执行的游戏/场景
+
+### 不同点
+
+1. **资源格式**: PNG vs GLB
+2. **技术栈**: Python/Pygame vs JavaScript/WebGL
+3. **运行环境**: Python 解释器 vs 浏览器
+4. **3D 节点**: 2D 无需 Image3DConvert，3D 必须
+
+## 功能完整性评估
+
+✅ **已实现**:
+
+- 基础 three.js 场景生成
+- 自动模型加载和定位
+- 光照系统
+- 相机控制
+- 简单动画
+- Agent 增强接口
+
+⚠️ **可改进**:
+
+- 模型定位算法（当前为简单圆形布局）
+- 碰撞检测
+- 游戏逻辑生成（依赖 agent）
+- VR/AR 支持
+- 物理引擎集成
+
+🔄 **与 2D 对等**:
+
+- 2D: 生成可玩的 pygame 游戏（有游戏循环、输入处理、碰撞）
+- 3D: 生成可交互的 three.js 场景（有渲染循环、轨道控制、模型展示）
+- **结论**: 功能对等，但 3D 侧重展示，2D 侧重游戏逻辑
+
+## 总结
+
+### 设计决策
+
+1. **替换而非扩展**: 3D 模式完全替换 AssemblyNode，而非扩展它
+
+   - **理由**: Pygame 和 Three.js 技术栈完全不同，强行统一会增加复杂度
+
+2. **模板 + 动态生成**: 使用 HTML 模板 + 动态填充
+
+   - **理由**: 保证基础场景可用，agent 增强为可选
+
+3. **Agent 可选**: ThreeJSAssemblyNode 先生成基础可用 HTML，agent 增强为可选步骤
+   - **理由**: 避免 agent 生成错误导致整个场景不可用
+
+### 与 2D Assembly 对比
+
+| 维度     | 2D Assembly     | 3D Assembly     | 一致性             |
+| -------- | --------------- | --------------- | ------------------ |
+| 可运行性 | ✅              | ✅              | ✓ 都生成可运行程序 |
+| 资源使用 | ✅              | ✅              | ✓ 都使用生成的资源 |
+| 交互性   | ✅ 完整游戏逻辑 | ⚠️ 基础场景展示 | △ 2D 更完善        |
+| 扩展性   | ⚠️ Pygame 限制  | ✅ Web 生态丰富 | △ 各有优劣         |
+
+**最终答案**: 3D 的 ThreeJSAssembly 与 2D 的 Assembly **功能对等但实现不同**：
+
+- 都生成可运行、可交互的程序
+- 都使用 pipeline 生成的资源
+- 2D 侧重完整游戏逻辑，3D 侧重场景展示和扩展性
+- 3D 通过 agent 增强可达到 2D 的交互复杂度

--- a/SOKOBAN_INSTRUCTIONS.txt
+++ b/SOKOBAN_INSTRUCTIONS.txt
@@ -1,0 +1,296 @@
+================================================================================
+3D SOKOBAN GAME GENERATION INSTRUCTIONS
+================================================================================
+
+VERSION 1: BASIC
+--------------------------------------------------------------------------------
+
+A 3D Sokoban puzzle game with simple geometric blocks.
+Features:
+- Isometric 3D perspective
+- Clean, minimalist aesthetic
+- The player controls a small cube to push boxes onto goal tiles
+
+
+VERSION 2: STANDARD (RECOMMENDED)
+--------------------------------------------------------------------------------
+
+A 3D Sokoban puzzle game with detailed isometric graphics.
+
+Visual Style:
+- Isometric 3D view (26.565 degrees)
+- Modern minimalist design with clean geometry
+- Low-poly but detailed 3D models
+- Smooth color gradients and soft shading
+
+Game Elements:
+1. Player Character: A blue cube with subtle shading, represents the player
+2. Pushable Box: Orange-red cube with directional indicator, must be pushed to goals
+3. Goal Platform: Green-glowing base tile where boxes must be placed
+4. Floor Tiles: Light gray base tiles with subtle grid pattern
+5. Walls: Dark blue-gray tall blocks that block movement
+6. Pressure Plates: Gray tiles with raised circular button
+7. Elevated Platforms: Blue transparent platform segments
+8. Environmental Details: Shadows and lighting effects
+
+
+VERSION 3: ADVANCED
+--------------------------------------------------------------------------------
+
+A sophisticated 3D Sokoban puzzle game with complex geometric assets.
+
+Art Direction:
+- Isometric 3D rendering with proper depth perception
+- Modern minimalist sci-fi aesthetic (similar to Monument Valley)
+- Three-face shading for cubes (top face lightest, left medium, right darkest)
+- Professional lighting with subtle gradients
+
+Detailed Asset Requirements:
+
+1. PLAYER_CHARACTER (Cyan Cube)
+   - 32x32x32 unit isometric cube
+   - Vibrant cyan (#3498DB) with three-face shading
+   - Dark outline for edge definition
+   - Small highlight indicator on top surface
+   - Clean geometric form, no soft shadows
+
+2. PUSHABLE_BOX (Orange Cube)
+   - Same geometry as player cube
+   - Warm orange (#E67E22) color
+   - Directional arrow on top face
+   - Identical three-face shading to player
+   - Geometric edge highlights
+
+3. GOAL_PLATFORM (Glowing Base)
+   - Isometric diamond floor shape (64x32 pixels)
+   - Mint green center (#1ABC9C)
+   - Subtle inner glow effect
+   - Three-face shading matching player lighting
+   - Seamlessly tileable edges
+
+4. FLOOR_TILES (Grid Pattern)
+   - Light gray base (#BDC3C7) with darker grid (#95A5A6)
+   - Isometric diamond 64x32 shape
+   - Subtle gradient for depth
+   - Clean geometric edges
+   - Repeating pattern for tileable game board
+
+5. WALL_BLOCKS (Tall Obstacles)
+   - Dark blue-gray (#2C3E50) tall cube (32x32x64)
+   - Double-height blocking element
+   - Geometric panel lines on surfaces
+   - Three-face shading for consistency
+   - Sharp, clean edges
+
+6. PRESSURE_PLATE (Interactive Floor)
+   - Gray floor tile (#95A5A6) with mechanical button
+   - Raised circular button element in center
+   - Geometric panel details
+   - Three-face shading matching walls
+   - Tileable design
+
+7. BRIDGE_SEGMENT (Glass Platform)
+   - Extended transparent platform
+   - Light blue (#3498DB) semi-transparent material
+   - Ethereal quality with subtle inner glow
+   - Same tileable base shape as goal platform
+   - Layered depth effect
+
+8. SHADOW_SPRITE (Lighting Effect)
+   - Soft elliptical shadow element
+   - Black with radial fade to transparent
+   - Subtle blur effect
+   - Matches player/box lighting direction (top-left)
+   - Non-tileable unique element
+
+Color Palette:
+- Primary Blue: #3498DB (player, bridges, accents)
+- Secondary Orange: #E67E22 (boxes, interactive elements)
+- Accent Green: #1ABC9C (goals, success indicators)
+- Background Gray: #BDC3C7 (floor, base)
+- Detail Gray: #95A5A6 (grid, edges)
+- Dark Blue: #2C3E50 (walls, obstacles)
+
+Rendering Requirements:
+- Low-poly geometric style (1000-10000 polygons per asset)
+- Flat shading with color blocks (no photo-realism)
+- Isometric projection consistency
+- Clear silhouettes and edge definition
+- Proper UV mapping for tileable elements
+- No bloom or glow shaders (use painted highlights instead)
+- High contrast for clarity in small sizes
+
+Technical Specifications:
+- Target Resolution: 64x64 pixels (2D), upscale to 3D models
+- Target Polycount: 10000 per asset maximum
+- Format: GLB (binary glTF) for three.js compatibility
+- Scale: Maintain consistent unit proportions
+- Optimization: Baked lighting, no dynamic shadows
+
+
+VERSION 4: ULTRA-DETAILED
+--------------------------------------------------------------------------------
+
+A premium 3D Sokoban puzzle game with rich visual design and complex assets.
+
+Design Philosophy:
+Modern minimalist with influences from Monument Valley, Portal 2 and Deus Ex: Human Revolution.
+Emphasize clean geometry, strategic color palette, and professional lighting.
+Create a cohesive isometric world with consistent art direction across all assets.
+
+ENVIRONMENT & FOUNDATION:
+
+Floor System:
+- Primary floor: Matte light gray (#BDC3C7) with embossed grid pattern
+- Grid spacing indicates 1-unit squares for game logic clarity
+- Subtle beveled edges for depth perception
+- Multiple surface variations: standard, slightly worn, polished
+- Seamlessly tileable with perfect edge matching
+- Supports 4-directional rotation without visual breaks
+
+Wall Architecture:
+- Main walls: Dark steel blue-gray (#2C3E50) with vertical panel lines
+- Wall surfaces show geometric segmentation (3x3 panel grid)
+- Recessed panel lines with subtle shadow lines
+- Multiple heights: standard (1 unit), tall (2 units), short (0.5 units)
+- Rounded corner options for variety
+- Strategic lighting to show wall depth and solidity
+
+GAMEPLAY ASSETS:
+
+Player Avatar (Sokoban Agent):
+- Form: Perfect cube, 32x32x32 units in isometric space
+- Material: Matte cyan (#3498DB) with metallic edge highlights
+- Surface Detail: Subtle beveled edges, not rounded
+- Orientation Indicator: Forward-facing arrow/marker on top
+- Animation Readiness: Smooth geometry for rotation/movement
+- Lighting: Three-face model - top face brightest, left medium, right darkest
+- Special Effect: Thin 1-pixel accent line on edges for definition
+
+Pushable Crate (Box Object):
+- Form: Identical cube geometry to player
+- Material: Warm terra-orange (#E67E22) with directional arrow
+- Surface Markers: Numbered or lettered (if multiple crates)
+- Edge Highlight: Single highlight line on top-left edge
+- Pushable Indicator: Clear visual distinction from walls
+- Animation: Smooth edges for rolling animation
+- Contrast: Distinct enough from environment to read at small scale
+
+Goal Receptacle (Target Platform):
+- Form: Isometric diamond floor tile (64x32 in plan view, 32 in height)
+- Primary Color: Mint green (#1ABC9C) glowing surface
+- Glow Effect: Subtle soft halo, not bloom - use painted gradient instead
+- Surface Pattern: Circular target reticle or concentric rings
+- State Indication: Visual change when box is placed (optional)
+- Lighting: Maintains three-face shading consistency
+- Multiple Variants: Regular goal, bonus goal, checkpoint indicator
+
+Obstacle & Environmental Elements:
+
+Pressure Plate (Trigger Tile):
+- Base: Gray floor (#95A5A6) with raised circular button center
+- Button Form: Raised dome (half-sphere) protruding from floor
+- Activation Visual: Button depression or color change concept
+- Surrounding: Beveled edge frame around button
+- Tileable: Compatible with standard floor tiles
+- States: Unpressed (raised), pressed (sunken), activated (glowing)
+
+Bridge/Corridor Extension:
+- Material: Translucent cyan glass (#3498DB at 70% opacity)
+- Form: Extended rectangular platform segment
+- Visual Effect: Subtle internal glow from edges only
+- Pattern: Geometric grid overlay representing structure
+- Integration: Blends with standard floor tiles
+- Safety: Clear edge definition for pathfinding visibility
+
+Fragile Floor (Hazard Element):
+- Base: Lighter gray (#D5DBDB) with crack pattern
+- Crack Graphics: Radial cracks from center, subtle depth lines
+- Animation Ready: Geometry for breaking/falling effect
+- Warning Visual: Maybe slight color tint difference from normal floor
+- Integrity Indicator: Visual degradation options available
+- Danger Signaling: Subtle visual cue without being obvious
+
+ATMOSPHERIC & SPECIAL ELEMENTS:
+
+Shadows (Depth Indicator):
+- Form: Elliptical shadow sprite beneath moving objects
+- Material: Black (#000000) with radial transparency gradient
+- Size: Proportional to object height (60x30 for main objects)
+- Blur: Soft edge with feathered transition
+- Lighting Direction: Consistent top-left light source
+- Real-time: Follows object position for depth clarity
+
+Particle Effects (Visual Polish):
+- Success Particle: Golden/yellow sparkle burst when box placed
+- Failure Particle: Red/orange dust cloud for invalid placement
+- Movement Trail: Light blue path indicator (optional)
+- Geometry: Simple geometric shapes, not realistic physics
+
+ADVANCED VISUAL FEATURES:
+
+Lighting Model:
+- Primary Light: Top-left direction (45° from top, 45° from left)
+- Color Temperature: Cool white, slight blue tint
+- Shadow Intensity: Moderate, not harsh (avoid pure black shadows)
+- Ambient Lighting: Slight overall brightness to maintain clarity
+- Edge Lighting: Subtle accent lights on prominent edges
+- No real-time shadows: All lighting is baked into vertex colors
+
+Material Properties:
+- Finish: Matte (not shiny)
+- Specularity: Very low (only on specific highlight lines)
+- Metallic Accents: Subtle brass/copper edges on premium assets
+- Wear Patterns: Optional - aged look on high-use floor tiles
+- Biohazard Markings: Optional - sci-fi detail elements
+
+Color Harmony:
+- Analogous Color Scheme: Blues, teals, cyans
+- Complementary Accent: Orange/warm tones for interactive elements
+- Saturation: High saturation for game elements, muted for environment
+- Value Contrast: Clear distinction between player, boxes, goals, obstacles
+- Colorblind Friendly: Pattern differentiation beyond color alone
+
+TECHNICAL SPECIFICATIONS:
+
+Model Optimization:
+- Polygon Target: 4,000-8,000 per asset
+- Texture Resolution: 1024x1024 base, scaled for tile-ability
+- File Format: GLB with embedded textures for three.js
+- Vertex Colors: Baked lighting as vertex color information
+- Normal Maps: High-quality for edge definition
+- Materials: PBR-ready but with stylized settings
+
+Performance Considerations:
+- LOD Levels: Optional second level of detail for distant view
+- Instancing: All floor tiles identical for draw call optimization
+- Batching: Group similar asset types in scene rendering
+- Animation: GPU-ready skeleton setup (optional)
+
+Consistency Requirements:
+- Scale: All assets maintain proportional isometric dimensions
+- Lighting: Identical light source position across all models
+- Orientation: Consistent front/back definition
+- Accessibility: No details smaller than 2 pixels at game scale
+- Clarity: Readable at 32x32 pixel display size minimum
+
+DELIVERY EXPECTATIONS:
+
+Quality Metrics:
+✓ Professional appearance at target resolution
+✓ Clear silhouettes without ambiguity
+✓ Consistent aesthetic across all assets
+✓ Optimized for real-time 3D engine (three.js)
+✓ Readable colors with proper contrast
+✓ Seamless tiling where applicable
+✓ Animation-ready geometry where needed
+✓ Accessible to colorblind players
+
+File Organization:
+- One .glb file per asset type
+- Clear naming convention (asset_name.glb)
+- Proper material assignments for visual clarity
+- Baked lighting for immediate rendering
+- Ready for integration into game engine
+
+

--- a/autoenv/pipeline/__init__.py
+++ b/autoenv/pipeline/__init__.py
@@ -3,7 +3,7 @@ AutoEnv Pipeline Module
 Unified pipeline module exports.
 
 Includes:
-- visual: Visualization pipeline (VisualPipeline)
+- visual: Visualization pipeline (VisualPipeline with optional 3D conversion)
 - generator: Environment generation pipeline (GeneratorPipeline)
 """
 
@@ -23,9 +23,11 @@ from autoenv.pipeline.visual import (
     AssemblyNode,
     AssetGeneratorNode,
     AutoEnvContext,
-    VisualPipeline,
     BackgroundRemovalNode,
+    Image3DConvertNode,
+    MeshyClient,
     StrategistNode,
+    VisualPipeline,
 )
 
 __all__ = [
@@ -37,6 +39,8 @@ __all__ = [
     "AssetGeneratorNode",
     "BackgroundRemovalNode",
     "AssemblyNode",
+    "Image3DConvertNode",
+    "MeshyClient",
     # Generator Pipeline
     "GeneratorPipeline",
     "GeneratorContext",

--- a/autoenv/pipeline/visual/README_3D.md
+++ b/autoenv/pipeline/visual/README_3D.md
@@ -1,0 +1,209 @@
+# 3D Scene Generation with Three.js
+
+## 概述
+
+在 3D 模式下，AutoEnv pipeline 生成基于 three.js 的可交互 3D 场景，而非 2D 的 pygame 游戏。
+
+## Pipeline 对比
+
+### 2D 模式 (dimension="2d")
+
+```
+Analyzer → Strategist → AssetGenerator → BackgroundRemoval → AssemblyNode
+输出: game/game.py + game/assets/*.png (Pygame游戏)
+```
+
+### 3D 模式 (dimension="3d")
+
+```
+Analyzer → Strategist → AssetGenerator → BackgroundRemoval → Image3DConvert → ThreeJSAssemblyNode
+输出: game/index.html + game/models/*.glb (Three.js场景)
+```
+
+## 功能对比
+
+| 功能     | 2D (Pygame)     | 3D (Three.js)    |
+| -------- | --------------- | ---------------- |
+| 渲染引擎 | Pygame (Python) | Three.js (WebGL) |
+| 资源格式 | PNG 图片        | GLB 3D 模型      |
+| 运行环境 | Python 解释器   | 浏览器           |
+| 相机控制 | 2D 平面移动     | 3D 轨道/FPS 控制 |
+| 光照     | 无/简单         | 完整光照系统     |
+| 物理     | 简单碰撞        | 可集成物理引擎   |
+| 交互性   | 键盘/鼠标       | 键盘/鼠标/VR     |
+
+## 使用方法
+
+### 生成 3D 场景
+
+```python
+from autoenv.pipeline.visual.pipeline import VisualPipeline
+
+pipeline = VisualPipeline.create_default(
+    image_model="gemini-2.5-flash-image",
+    dimension="3d",  # 启用3D模式
+    meshy_api_key="your-meshy-key",
+    max_3d_assets=4
+)
+
+await pipeline.run(
+    instruction="A 3D Sokoban puzzle game",
+    output_dir=Path("output/game_3d")
+)
+```
+
+### 查看生成的 3D 场景
+
+1. **本地 HTTP 服务器** (推荐):
+
+   ```bash
+   cd output/game_3d/game
+   python -m http.server 8000
+   # 打开浏览器访问: http://localhost:8000
+   ```
+
+2. **直接打开** (可能受 CORS 限制):
+   ```bash
+   open output/game_3d/game/index.html
+   ```
+
+## 生成文件结构
+
+```
+output/game_3d/
+├── analysis.json          # 需求分析
+├── strategy.json          # 可视化策略
+├── assets/                # 原始2D图片
+│   ├── player.png
+│   ├── box.png
+│   └── ...
+├── models_3d/             # 转换后的3D模型
+│   ├── player.glb
+│   ├── box.glb
+│   └── ...
+├── 3d_timing_log.json    # 转换性能日志
+└── game/                  # 可运行的游戏
+    ├── index.html         # Three.js场景入口
+    └── models/            # 3D模型副本
+        ├── player.glb
+        ├── box.glb
+        └── ...
+```
+
+## Three.js 场景功能
+
+### 内置功能
+
+1. **相机控制**:
+
+   - 左键拖动: 旋转视角
+   - 右键拖动: 平移
+   - 滚轮: 缩放
+   - WASD 键: 移动相机目标
+
+2. **光照系统**:
+
+   - 环境光 (AmbientLight)
+   - 方向光 (DirectionalLight) + 阴影
+
+3. **模型加载**:
+
+   - GLTFLoader 异步加载所有.glb 模型
+   - 进度提示
+   - 自动启用阴影
+
+4. **场景布局**:
+   - 地面平面
+   - 网格辅助
+   - 基于策略的自动模型定位
+
+### Agent 增强 (可选)
+
+如果启用了`ThreeJSAssemblyNode`的 agent，会自动:
+
+- 添加游戏逻辑 (移动、碰撞、目标检测)
+- 优化模型位置和布局
+- 实现动画系统
+- 添加游戏状态管理
+
+## 自定义开发
+
+### 修改模板
+
+编辑 `autoenv/pipeline/visual/threejs_template.html`:
+
+```javascript
+// 自定义模型位置
+if (assetId === "player") {
+  model.position.set(0, 0, 0);
+  model.scale.setScalar(1.5);
+}
+
+// 自定义动画
+if (models["box"]) {
+  models["box"].rotation.y += 0.01; // 旋转动画
+}
+```
+
+### 集成物理引擎
+
+```javascript
+import RAPIER from "https://cdn.skypack.dev/@dimforge/rapier3d-compat";
+
+// 在animate()中更新物理
+world.step();
+```
+
+### 添加 VR 支持
+
+```javascript
+import { VRButton } from "three/addons/webxr/VRButton.js";
+renderer.xr.enabled = true;
+document.body.appendChild(VRButton.createButton(renderer));
+```
+
+## 性能优化
+
+1. **减少多边形数**: 调整`target_polycount`参数
+
+   ```python
+   pipeline = VisualPipeline.create_default(
+       dimension="3d",
+       target_polycount=5000  # 默认10000
+   )
+   ```
+
+2. **限制转换数量**: 设置`max_3d_assets`
+
+   ```python
+   max_3d_assets=3  # 只转换前3个重要资源
+   ```
+
+3. **并行转换**: Image3DConvertNode 自动并行处理所有模型
+
+## 已知限制
+
+1. **Meshy API 配额**: 免费版有转换次数限制
+2. **模型质量**: 取决于输入图片质量和 Meshy 转换效果
+3. **浏览器兼容性**: 需支持 WebGL 2.0
+4. **文件大小**: GLB 模型比 PNG 大，注意带宽
+
+## 故障排除
+
+### 模型加载失败
+
+- 检查`models/`目录是否有.glb 文件
+- 确认使用 HTTP 服务器而非直接打开 HTML (CORS 限制)
+- 查看浏览器控制台错误信息
+
+### 性能问题
+
+- 降低`target_polycount`
+- 减少`max_3d_assets`数量
+- 简化模型材质和纹理
+
+### Agent 生成的代码有问题
+
+- ThreeJSAssemblyNode 首先生成基础可用模板
+- Agent 增强是可选的，可禁用 agent 参数
+- 手动修改 index.html 进行调试

--- a/autoenv/pipeline/visual/__init__.py
+++ b/autoenv/pipeline/visual/__init__.py
@@ -1,8 +1,9 @@
 """
 AutoEnv Pipeline Module
-DAG-based environment generation pipeline.
+DAG-based environment generation pipeline with optional 3D conversion.
 """
 
+from autoenv.pipeline.visual.meshy_client import MeshyClient
 from autoenv.pipeline.visual.nodes import (
     AgentNode,
     AnalyzerNode,
@@ -10,6 +11,7 @@ from autoenv.pipeline.visual.nodes import (
     AssemblyNode,
     AutoEnvContext,
     BackgroundRemovalNode,
+    Image3DConvertNode,
     StrategistNode,
 )
 from autoenv.pipeline.visual.pipeline import VisualPipeline
@@ -22,5 +24,7 @@ __all__ = [
     "AutoEnvContext",
     "BackgroundRemovalNode",
     "StrategistNode",
+    "Image3DConvertNode",
+    "MeshyClient",
     "VisualPipeline",
 ]

--- a/autoenv/pipeline/visual/meshy_client.py
+++ b/autoenv/pipeline/visual/meshy_client.py
@@ -1,0 +1,308 @@
+"""
+Meshy API Client for Image-to-3D conversion.
+
+Uses the Meshy AI API to convert 2D images to 3D models.
+API Documentation: https://docs.meshy.ai/en/api/image-to-3d
+"""
+
+import asyncio
+import base64
+import time
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+
+
+class MeshyClient:
+    """Async client for Meshy Image-to-3D API."""
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = "https://api.meshy.ai/v1",
+    ):
+        """
+        Initialize Meshy client.
+
+        Args:
+            api_key: Meshy API key
+            base_url: API base URL
+        """
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def image_to_data_uri(self, image_path: Path) -> str:
+        """
+        Convert image file to Data URI format.
+
+        Args:
+            image_path: Path to the image file
+
+        Returns:
+            Data URI string (data:image/png;base64,...)
+        """
+        with open(image_path, "rb") as f:
+            image_bytes = f.read()
+        b64 = base64.b64encode(image_bytes).decode("utf-8")
+
+        # Determine MIME type
+        suffix = image_path.suffix.lower()
+        mime_map = {
+            ".png": "image/png",
+            ".jpg": "image/jpeg",
+            ".jpeg": "image/jpeg",
+            ".webp": "image/webp",
+        }
+        mime_type = mime_map.get(suffix, "image/png")
+
+        return f"data:{mime_type};base64,{b64}"
+
+    def base64_to_data_uri(self, b64: str, mime_type: str = "image/png") -> str:
+        """
+        Convert base64 string to Data URI format.
+
+        Args:
+            b64: Base64 encoded image string
+            mime_type: MIME type of the image
+
+        Returns:
+            Data URI string
+        """
+        # Remove existing data URI prefix if present
+        if b64.startswith("data:"):
+            return b64
+        return f"data:{mime_type};base64,{b64}"
+
+    async def create_image_to_3d_task(
+        self,
+        image_data_uri: str,
+        topology: str = "quad",
+        target_polycount: int = 10000,
+        should_remesh: bool = True,
+        enable_pbr: bool = True,
+    ) -> dict[str, Any]:
+        """
+        Create an Image-to-3D task.
+
+        Args:
+            image_data_uri: Data URI of the input image
+            topology: Mesh topology ("quad" or "triangle")
+            target_polycount: Target polygon count (keep low for faster processing)
+            should_remesh: Whether to remesh the output
+            enable_pbr: Enable PBR textures
+
+        Returns:
+            API response with task ID
+        """
+        url = f"{self.base_url}/image-to-3d"
+        payload = {
+            "image_url": image_data_uri,
+            "topology": topology,
+            "target_polycount": target_polycount,
+            "should_remesh": should_remesh,
+            "enable_pbr": enable_pbr,
+        }
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=payload, headers=self.headers) as resp:
+                if resp.status != 200 and resp.status != 202:
+                    error_text = await resp.text()
+                    return {
+                        "success": False,
+                        "error": f"HTTP {resp.status}: {error_text}",
+                    }
+                data = await resp.json()
+                return {
+                    "success": True,
+                    "task_id": data.get("result"),
+                    "response": data,
+                }
+
+    async def get_task_status(self, task_id: str) -> dict[str, Any]:
+        """
+        Get the status of an Image-to-3D task.
+
+        Args:
+            task_id: The task ID to check
+
+        Returns:
+            Task status and result
+        """
+        url = f"{self.base_url}/image-to-3d/{task_id}"
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=self.headers) as resp:
+                if resp.status != 200:
+                    error_text = await resp.text()
+                    return {
+                        "success": False,
+                        "error": f"HTTP {resp.status}: {error_text}",
+                    }
+                data = await resp.json()
+                return {
+                    "success": True,
+                    "status": data.get("status"),
+                    "progress": data.get("progress", 0),
+                    "model_urls": data.get("model_urls", {}),
+                    "thumbnail_url": data.get("thumbnail_url"),
+                    "response": data,
+                }
+
+    async def wait_for_task(
+        self,
+        task_id: str,
+        timeout: float = 600,  # 10 minutes default timeout
+        poll_interval: float = 5.0,
+        progress_callback=None,
+    ) -> dict[str, Any]:
+        """
+        Wait for an Image-to-3D task to complete.
+
+        Args:
+            task_id: The task ID to wait for
+            timeout: Maximum time to wait in seconds
+            poll_interval: Time between status checks
+            progress_callback: Optional callback for progress updates
+
+        Returns:
+            Final task result
+        """
+        start_time = time.time()
+        last_progress = -1
+
+        while True:
+            elapsed = time.time() - start_time
+            if elapsed > timeout:
+                return {
+                    "success": False,
+                    "error": f"Timeout after {timeout}s",
+                    "task_id": task_id,
+                }
+
+            status = await self.get_task_status(task_id)
+            if not status["success"]:
+                return status
+
+            current_status = status.get("status", "")
+            progress = status.get("progress", 0)
+
+            # Report progress if changed
+            if progress != last_progress and progress_callback:
+                progress_callback(task_id, current_status, progress)
+            last_progress = progress
+
+            if current_status == "SUCCEEDED":
+                return {
+                    "success": True,
+                    "status": "SUCCEEDED",
+                    "model_urls": status.get("model_urls", {}),
+                    "thumbnail_url": status.get("thumbnail_url"),
+                    "task_id": task_id,
+                    "elapsed_time": elapsed,
+                }
+            elif current_status == "FAILED":
+                return {
+                    "success": False,
+                    "status": "FAILED",
+                    "error": status.get("response", {}).get("message", "Task failed"),
+                    "task_id": task_id,
+                }
+            elif current_status == "EXPIRED":
+                return {
+                    "success": False,
+                    "status": "EXPIRED",
+                    "error": "Task expired",
+                    "task_id": task_id,
+                }
+
+            await asyncio.sleep(poll_interval)
+
+    async def image_to_3d(
+        self,
+        image_path: Path | None = None,
+        image_base64: str | None = None,
+        timeout: float = 600,
+        progress_callback=None,
+        target_polycount: int = 10000,
+    ) -> dict[str, Any]:
+        """
+        Convert image to 3D model (full workflow).
+
+        Args:
+            image_path: Path to input image (provide either this or image_base64)
+            image_base64: Base64 encoded image (provide either this or image_path)
+            timeout: Maximum time to wait for completion
+            progress_callback: Optional callback for progress updates
+            target_polycount: Target polygon count
+
+        Returns:
+            Result with model URLs or error
+        """
+        # Convert to Data URI
+        if image_path:
+            data_uri = self.image_to_data_uri(image_path)
+        elif image_base64:
+            data_uri = self.base64_to_data_uri(image_base64)
+        else:
+            return {"success": False, "error": "Provide image_path or image_base64"}
+
+        # Create task
+        task_result = await self.create_image_to_3d_task(
+            image_data_uri=data_uri,
+            target_polycount=target_polycount,
+        )
+
+        if not task_result["success"]:
+            return task_result
+
+        task_id = task_result["task_id"]
+
+        # Wait for completion
+        return await self.wait_for_task(
+            task_id=task_id,
+            timeout=timeout,
+            progress_callback=progress_callback,
+        )
+
+    async def download_model(
+        self,
+        model_url: str,
+        output_path: Path,
+    ) -> dict[str, Any]:
+        """
+        Download a 3D model file.
+
+        Args:
+            model_url: URL of the model file
+            output_path: Path to save the model
+
+        Returns:
+            Result with success status
+        """
+        try:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+
+            async with aiohttp.ClientSession() as session:
+                async with session.get(model_url) as resp:
+                    if resp.status != 200:
+                        return {
+                            "success": False,
+                            "error": f"HTTP {resp.status}",
+                        }
+                    content = await resp.read()
+                    output_path.write_bytes(content)
+
+            return {
+                "success": True,
+                "path": str(output_path),
+            }
+        except Exception as e:
+            return {
+                "success": False,
+                "error": str(e),
+            }

--- a/autoenv/pipeline/visual/nodes.py
+++ b/autoenv/pipeline/visual/nodes.py
@@ -63,6 +63,7 @@ class AutoEnvContext(NodeContext):
     # AssemblyNode output
     game_dir: Path | None = None
     game_file: Path | None = None
+    skin_manifest: dict[str, Any] = Field(default_factory=dict)
     success: bool = False
     error: str | None = None
 
@@ -306,6 +307,17 @@ class AssemblyNode(AgentNode):
             ctx.game_dir = game_dir
             ctx.game_file = game_dir / "game.py"
             ctx.success = True
+
+        if ctx.success and ctx.game_file:
+            ctx.skin_manifest = {
+                "modality": "2d",
+                "entrypoint": str(ctx.game_file),
+                "artifacts": {
+                    "game_dir": str(game_dir),
+                    "assets_dir": str(assets_dst),
+                },
+                "asset_ids": sorted(ctx.generated_assets.keys()),
+            }
 
     def _build_game_code_prompt(self, ctx: AutoEnvContext) -> str:
         """Build game code generation prompt based on source type"""
@@ -668,6 +680,16 @@ class ThreeJSAssemblyNode(AgentNode):
             ctx.game_dir = game_dir
             ctx.game_file = html_file
             ctx.success = True
+            ctx.skin_manifest = {
+                "modality": "3d",
+                "entrypoint": str(html_file),
+                "artifacts": {
+                    "game_dir": str(game_dir),
+                    "models_dir": str(models_dst),
+                },
+                "asset_ids": sorted(ctx.models_3d.keys()),
+                "model_count": len(ctx.models_3d),
+            }
             print(f"[ThreeJSAssembly] ✓ Generated: {html_file}")
             print(f"[ThreeJSAssembly] To view: Open {html_file} in browser or run: python -m http.server --directory {game_dir}")
 

--- a/autoenv/pipeline/visual/pipeline.py
+++ b/autoenv/pipeline/visual/pipeline.py
@@ -4,6 +4,7 @@ DAG-based environment generation pipeline
 """
 
 from pathlib import Path
+from typing import Optional
 
 from autoenv.miniswe_agent import MiniSWEAutoEnvAgent
 from autoenv.pipeline.visual.nodes import (
@@ -12,7 +13,9 @@ from autoenv.pipeline.visual.nodes import (
     AssemblyNode,
     AutoEnvContext,
     BackgroundRemovalNode,
+    Image3DConvertNode,
     StrategistNode,
+    ThreeJSAssemblyNode,
 )
 from base.engine.async_llm import AsyncLLM
 from base.pipeline.base_pipeline import BasePipeline
@@ -20,10 +23,13 @@ from base.pipeline.base_pipeline import BasePipeline
 
 class VisualPipeline(BasePipeline):
     """
-    Visualization pipeline.
+    Visualization pipeline with optional 3D conversion.
 
-    DAG structure:
-        Analyzer → Strategist → AssetGenerator → BackgroundRemoval → Assembly
+    DAG structure (2D mode):
+        Analyzer → Strategist → AssetGenerator → BackgroundRemoval → Assembly (pygame)
+    
+    DAG structure (3D mode):
+        Analyzer → Strategist → AssetGenerator → BackgroundRemoval → Image3DConvert → ThreeJSAssembly (three.js)
     """
 
     model_config = {"arbitrary_types_allowed": True}
@@ -33,21 +39,39 @@ class VisualPipeline(BasePipeline):
         cls,
         image_model: str,
         llm_name: str = "claude-sonnet-4-5",
+        dimension: str = "2d",
+        meshy_api_key: str = "",
+        meshy_base_url: str = "https://api.meshy.ai/v1",
+        max_3d_assets: int = 4,
+        target_polycount: int = 10000,
     ) -> "VisualPipeline":
         """
-        Factory method: Create default visualization pipeline.
+        Factory method: Create visualization pipeline with optional 3D support.
 
         Args:
             image_model: Image generation model name (required)
             llm_name: LLM name for agents
+            dimension: "2d" or "3d" - determines if 3D conversion is enabled
+            meshy_api_key: Meshy API key for 3D conversion (required if dimension="3d")
+            meshy_base_url: Meshy API base URL
+            max_3d_assets: Maximum number of assets to convert to 3D
+            target_polycount: Target polygon count for 3D models
 
         Usage:
+            # 2D pipeline
             pipeline = VisualPipeline.create_default(
                 image_model="gemini-2.5-flash-image",
-                llm_name="gemini-2.5-flash"
+                dimension="2d"
             )
-            ctx = await pipeline.run()
+            
+            # 3D pipeline
+            pipeline = VisualPipeline.create_default(
+                image_model="gemini-2.5-flash-image",
+                dimension="3d",
+                meshy_api_key="your-key"
+            )
         """
+        # Create agents
         analyzer_agent = MiniSWEAutoEnvAgent(
             llm_name=llm_name,
             mode="yolo",
@@ -66,6 +90,15 @@ class VisualPipeline(BasePipeline):
             cwd=str(Path.cwd()),
         )
 
+        threejs_agent = MiniSWEAutoEnvAgent(
+            llm_name=llm_name,
+            mode="yolo",
+            step_limit=60,
+            cost_limit=12.0,
+            environment_type="local",
+            cwd=str(Path.cwd()),
+        )
+
         assembly_agent = MiniSWEAutoEnvAgent(
             llm_name=llm_name,
             mode="yolo",
@@ -77,13 +110,27 @@ class VisualPipeline(BasePipeline):
 
         image_llm = AsyncLLM(image_model)
 
+        # Create core nodes
         analyzer = AnalyzerNode(agent=analyzer_agent)
         strategist = StrategistNode(agent=strategist_agent)
         asset_generator = AssetGeneratorNode(image_llm=image_llm)
         bg_removal = BackgroundRemovalNode()
-        assembly = AssemblyNode(agent=assembly_agent)
 
-        analyzer >> strategist >> asset_generator >> bg_removal >> assembly
+        # Build pipeline DAG based on dimension
+        if dimension == "3d":
+            # 3D pipeline: add 3D conversion + three.js assembly
+            image_to_3d = Image3DConvertNode(
+                meshy_api_key=meshy_api_key,
+                meshy_base_url=meshy_base_url,
+                max_assets_to_convert=max_3d_assets,
+                target_polycount=target_polycount,
+            )
+            threejs_assembly = ThreeJSAssemblyNode(agent=threejs_agent)
+            analyzer >> strategist >> asset_generator >> bg_removal >> image_to_3d >> threejs_assembly
+        else:
+            # 2D pygame pipeline
+            assembly = AssemblyNode(agent=assembly_agent)
+            analyzer >> strategist >> asset_generator >> bg_removal >> assembly
 
         return cls(root=analyzer)
 

--- a/autoenv/pipeline/visual/prompt.py
+++ b/autoenv/pipeline/visual/prompt.py
@@ -359,3 +359,34 @@ while running:
 
 pygame.quit()
 '''
+
+# ============== 3D Scene Enhancement Prompt ==============
+
+ENHANCEMENT_PROMPT = """You are enhancing a three.js 3D game scene. The current HTML file is at: {html_file}
+
+Available 3D models:
+{model_list}
+
+Game strategy:
+{strategy_json}
+
+Goal: Deliver a polished, visually refined and interactive 3D scene that plays smoothly, respects the strategy, and avoids rendering/interaction bugs.
+
+Tasks:
+1) Review the generated scene in {html_file}.
+2) Add robust interactive logic (e.g., player/agent movement, collision detection with boundaries/obstacles, clear objectives with win/lose or success/fail conditions.
+3) Improve model positioning to match the strategy (e.g., spawn zones, obstacles, collectibles, goals). Avoid overlapping or sunken models.
+4) Add sensible animations (e.g., idle, walk/run, interact) and simple feedback (highlights) that do not break performance.
+5) Implement camera controls: keep ORBIT; add FIRST-PERSON or follow camera only if it fits the game; prevent clipping through ground/objects and keep near/far planes reasonable.
+6) Add game state management (score/health/progress), UI hints if helpful, and reset/restart hooks.
+
+ Quality & safety requirements:
+ - Keep using the existing three.js CDN imports (modelPaths:models/asset_name.glb).
+ - Add three.js CDN assets for environmental enrichment if needed.
+ - Ensure stable rendering: enable shadows carefully, cap lights, avoid excessive post-processing; keep frame rate smooth.
+ - Ensure reliable interaction: solid ground, no falling through, prevent camera from going underground, clamp movement to play area, and guard against null/undefined models before use.
+ - Ensure the scene is playable and matches the strategy
+ - Keep the scene bright/clear (light background + ambientLight ≥ 1.0), and ensure player models visible and stay fully above ground/floor (use bounding box to lift if needed; add lights if still dark).
+
+ Output:
+ - Write back a single, working {html_file} with enhanced gameplay, controls, brightness/visibility, and safety checks (no separate files required)."""

--- a/autoenv/pipeline/visual/threejs_template.html
+++ b/autoenv/pipeline/visual/threejs_template.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>3D Game Scene - Three.js</title>
+    <style>
+        body {
+            margin: 0;
+            overflow: hidden;
+            font-family: Arial, sans-serif;
+        }
+        #canvas-container {
+            width: 100vw;
+            height: 100vh;
+        }
+        #info {
+            position: absolute;
+            top: 10px;
+            left: 10px;
+            color: white;
+            background: rgba(0, 0, 0, 0.5);
+            padding: 10px;
+            border-radius: 5px;
+            font-size: 14px;
+        }
+        #loading {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            color: white;
+            background: rgba(0, 0, 0, 0.7);
+            padding: 20px;
+            border-radius: 10px;
+            font-size: 18px;
+        }
+    </style>
+</head>
+<body>
+    <div id="canvas-container"></div>
+    <div id="loading">Loading 3D models...</div>
+    <div id="info">
+        Camera Controls:<br>
+        - Left Mouse: Rotate<br>
+        - Right Mouse: Pan<br>
+        - Scroll: Zoom<br>
+        - WASD: Move<br>
+        - Space: Jump (if applicable)
+    </div>
+
+    <!-- Three.js CDN -->
+    <script type="importmap">
+    {
+        "imports": {
+            "three": "https://cdn.jsdelivr.net/npm/three@0.170.0/build/three.module.js",
+            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.170.0/examples/jsm/"
+        }
+    }
+    </script>
+
+    <script type="module">
+        import * as THREE from 'three';
+        import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+        import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+
+        // ==== SCENE SETUP ====
+        const scene = new THREE.Scene();
+        scene.background = new THREE.Color(0x87CEEB); // Sky blue
+        
+        // Camera
+        const camera = new THREE.PerspectiveCamera(
+            75, 
+            window.innerWidth / window.innerHeight, 
+            0.1, 
+            1000
+        );
+        camera.position.set(5, 5, 5);
+        camera.lookAt(0, 0, 0);
+
+        // Renderer
+        const renderer = new THREE.WebGLRenderer({ antialias: true });
+        renderer.setSize(window.innerWidth, window.innerHeight);
+        renderer.shadowMap.enabled = true;
+        renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+        document.getElementById('canvas-container').appendChild(renderer.domElement);
+
+        // Controls
+        const controls = new OrbitControls(camera, renderer.domElement);
+        controls.enableDamping = true;
+        controls.dampingFactor = 0.05;
+        controls.minDistance = 2;
+        controls.maxDistance = 50;
+
+        // Lighting
+        const ambientLight = new THREE.AmbientLight(0xffffff, 0.5);
+        scene.add(ambientLight);
+
+        const directionalLight = new THREE.DirectionalLight(0xffffff, 1);
+        directionalLight.position.set(10, 20, 10);
+        directionalLight.castShadow = true;
+        directionalLight.shadow.camera.left = -20;
+        directionalLight.shadow.camera.right = 20;
+        directionalLight.shadow.camera.top = 20;
+        directionalLight.shadow.camera.bottom = -20;
+        directionalLight.shadow.mapSize.width = 2048;
+        directionalLight.shadow.mapSize.height = 2048;
+        scene.add(directionalLight);
+
+        // Ground plane
+        const groundGeometry = new THREE.PlaneGeometry(50, 50);
+        const groundMaterial = new THREE.MeshStandardMaterial({ 
+            color: 0x8B7355,
+            roughness: 0.8
+        });
+        const ground = new THREE.Mesh(groundGeometry, groundMaterial);
+        ground.rotation.x = -Math.PI / 2;
+        ground.receiveShadow = true;
+        scene.add(ground);
+
+        // Grid helper
+        const gridHelper = new THREE.GridHelper(50, 50, 0x000000, 0x000000);
+        gridHelper.material.opacity = 0.2;
+        gridHelper.material.transparent = true;
+        scene.add(gridHelper);
+
+        // ==== LOAD 3D MODELS ====
+        const loader = new GLTFLoader();
+        const models = {};
+        let loadedCount = 0;
+        const totalModels = {MODEL_COUNT};
+
+        // Model paths (will be populated by Python)
+        const modelPaths = {MODEL_PATHS_JSON};
+
+        function updateLoadingStatus() {
+            const loadingDiv = document.getElementById('loading');
+            if (loadedCount >= totalModels) {
+                loadingDiv.style.display = 'none';
+            } else {
+                loadingDiv.textContent = `Loading 3D models... (${loadedCount}/${totalModels})`;
+            }
+        }
+
+        // Load each model
+        Object.entries(modelPaths).forEach(([assetId, modelPath]) => {
+            loader.load(
+                modelPath,
+                (gltf) => {
+                    const model = gltf.scene;
+                    model.name = assetId;
+                    
+                    // Enable shadows
+                    model.traverse((child) => {
+                        if (child.isMesh) {
+                            child.castShadow = true;
+                            child.receiveShadow = true;
+                        }
+                    });
+
+                    // Position models (customize based on strategy)
+                    {MODEL_POSITIONING_CODE}
+
+                    scene.add(model);
+                    models[assetId] = model;
+                    loadedCount++;
+                    updateLoadingStatus();
+                    console.log(`Loaded: ${assetId}`);
+                },
+                (progress) => {
+                    console.log(`Loading ${assetId}: ${(progress.loaded / progress.total * 100).toFixed(0)}%`);
+                },
+                (error) => {
+                    console.error(`Error loading ${assetId}:`, error);
+                    loadedCount++;
+                    updateLoadingStatus();
+                }
+            );
+        });
+
+        // ==== KEYBOARD CONTROLS ====
+        const keys = {};
+        document.addEventListener('keydown', (e) => keys[e.key.toLowerCase()] = true);
+        document.addEventListener('keyup', (e) => keys[e.key.toLowerCase()] = false);
+
+        const moveSpeed = 0.1;
+
+        // ==== ANIMATION LOOP ====
+        function animate() {
+            requestAnimationFrame(animate);
+
+            // Camera movement (WASD)
+            if (keys['w']) controls.target.z -= moveSpeed;
+            if (keys['s']) controls.target.z += moveSpeed;
+            if (keys['a']) controls.target.x -= moveSpeed;
+            if (keys['d']) controls.target.x += moveSpeed;
+
+            // Custom animations (will be populated by Python)
+            {ANIMATION_CODE}
+
+            controls.update();
+            renderer.render(scene, camera);
+        }
+
+        // Window resize handler
+        window.addEventListener('resize', () => {
+            camera.aspect = window.innerWidth / window.innerHeight;
+            camera.updateProjectionMatrix();
+            renderer.setSize(window.innerWidth, window.innerHeight);
+        });
+
+        animate();
+    </script>
+</body>
+</html>

--- a/autoenv/pipeline/visual/threejs_template.html
+++ b/autoenv/pipeline/visual/threejs_template.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -10,10 +11,12 @@
             overflow: hidden;
             font-family: Arial, sans-serif;
         }
+
         #canvas-container {
             width: 100vw;
             height: 100vh;
         }
+
         #info {
             position: absolute;
             top: 10px;
@@ -24,6 +27,7 @@
             border-radius: 5px;
             font-size: 14px;
         }
+
         #loading {
             position: absolute;
             top: 50%;
@@ -37,6 +41,7 @@
         }
     </style>
 </head>
+
 <body>
     <div id="canvas-container"></div>
     <div id="loading">Loading 3D models...</div>
@@ -67,12 +72,12 @@
         // ==== SCENE SETUP ====
         const scene = new THREE.Scene();
         scene.background = new THREE.Color(0x87CEEB); // Sky blue
-        
+
         // Camera
         const camera = new THREE.PerspectiveCamera(
-            75, 
-            window.innerWidth / window.innerHeight, 
-            0.1, 
+            75,
+            window.innerWidth / window.innerHeight,
+            0.1,
             1000
         );
         camera.position.set(5, 5, 5);
@@ -109,7 +114,7 @@
 
         // Ground plane
         const groundGeometry = new THREE.PlaneGeometry(50, 50);
-        const groundMaterial = new THREE.MeshStandardMaterial({ 
+        const groundMaterial = new THREE.MeshStandardMaterial({
             color: 0x8B7355,
             roughness: 0.8
         });
@@ -128,10 +133,10 @@
         const loader = new GLTFLoader();
         const models = {};
         let loadedCount = 0;
-        const totalModels = {MODEL_COUNT};
+        const totalModels = { MODEL_COUNT };
 
         // Model paths (will be populated by Python)
-        const modelPaths = {MODEL_PATHS_JSON};
+        const modelPaths = { MODEL_PATHS_JSON };
 
         function updateLoadingStatus() {
             const loadingDiv = document.getElementById('loading');
@@ -149,7 +154,7 @@
                 (gltf) => {
                     const model = gltf.scene;
                     model.name = assetId;
-                    
+
                     // Enable shadows
                     model.traverse((child) => {
                         if (child.isMesh) {
@@ -158,8 +163,15 @@
                         }
                     });
 
+                    // Ensure model sits on ground (prevent sinking below y=0)
+                    const bbox = new THREE.Box3().setFromObject(model);
+                    const minY = bbox.min.y;
+                    if (Number.isFinite(minY)) {
+                        model.position.y += -minY + 0.01; // small lift above ground
+                    }
+
                     // Position models (customize based on strategy)
-                    {MODEL_POSITIONING_CODE}
+                    { MODEL_POSITIONING_CODE }
 
                     scene.add(model);
                     models[assetId] = model;
@@ -196,7 +208,7 @@
             if (keys['d']) controls.target.x += moveSpeed;
 
             // Custom animations (will be populated by Python)
-            {ANIMATION_CODE}
+            { ANIMATION_CODE }
 
             controls.update();
             renderer.render(scene, camera);
@@ -212,4 +224,5 @@
         animate();
     </script>
 </body>
+
 </html>

--- a/autoenv/pipeline/visual/threejs_template.html
+++ b/autoenv/pipeline/visual/threejs_template.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -12,10 +13,12 @@
             font-family: Arial, sans-serif;
         }
 
+
         #canvas-container {
             width: 100vw;
             height: 100vh;
         }
+
 
         #info {
             position: absolute;
@@ -27,6 +30,7 @@
             border-radius: 5px;
             font-size: 14px;
         }
+
 
         #loading {
             position: absolute;
@@ -41,6 +45,7 @@
         }
     </style>
 </head>
+
 
 <body>
     <div id="canvas-container"></div>
@@ -71,10 +76,14 @@
 
         // ==== SCENE SETUP ====
         const scene = new THREE.Scene();
-        scene.background = new THREE.Color(0x87CEEB); // Sky blue
+        scene.background = new THREE.Color(0xA0A0A0); // Bright neutral background (NOT dark)
+        scene.fog = new THREE.Fog(0xA0A0A0, 50, 100); // Bright fog to match background
 
         // Camera
         const camera = new THREE.PerspectiveCamera(
+            75,
+            window.innerWidth / window.innerHeight,
+            0.1,
             75,
             window.innerWidth / window.innerHeight,
             0.1,
@@ -97,11 +106,11 @@
         controls.minDistance = 2;
         controls.maxDistance = 50;
 
-        // Lighting
-        const ambientLight = new THREE.AmbientLight(0xffffff, 0.5);
+        // Lighting - BRIGHT and CLEAR (default: well-lit scenes)
+        const ambientLight = new THREE.AmbientLight(0xffffff, 1.2); // Increased from 0.5 to 1.2
         scene.add(ambientLight);
 
-        const directionalLight = new THREE.DirectionalLight(0xffffff, 1);
+        const directionalLight = new THREE.DirectionalLight(0xffffff, 1.2); // Increased from 1 to 1.2
         directionalLight.position.set(10, 20, 10);
         directionalLight.castShadow = true;
         directionalLight.shadow.camera.left = -20;
@@ -155,6 +164,7 @@
                     const model = gltf.scene;
                     model.name = assetId;
 
+
                     // Enable shadows
                     model.traverse((child) => {
                         if (child.isMesh) {
@@ -164,13 +174,29 @@
                     });
 
                     // Ensure model sits on ground (prevent sinking below y=0)
+                    // Calculate accurate bounding box and adjust position
                     const bbox = new THREE.Box3().setFromObject(model);
+                    const modelHeight = bbox.max.y - bbox.min.y;
                     const minY = bbox.min.y;
-                    if (Number.isFinite(minY)) {
-                        model.position.y += -minY + 0.01; // small lift above ground
+
+                    // Move model up so its bottom is just above ground (y=0)
+                    if (Number.isFinite(minY) && minY < 0) {
+                        model.position.y += Math.abs(minY) + 0.01;
+                    }
+
+                    // Special handling for player/character models - ensure visibility
+                    if (assetId.toLowerCase().includes('player') ||
+                        assetId.toLowerCase().includes('character') ||
+                        assetId.toLowerCase().includes('avatar')) {
+                        // Move character up to ensure full visibility above ground
+                        model.position.y = Math.max(model.position.y, modelHeight * 0.5);
+                        // Adjust camera to focus on character
+                        camera.position.set(5, modelHeight + 3, 8);
+                        controls.target.set(0, modelHeight * 0.5, 0);
                     }
 
                     // Position models (customize based on strategy)
+                    { MODEL_POSITIONING_CODE }
                     { MODEL_POSITIONING_CODE }
 
                     scene.add(model);
@@ -209,6 +235,7 @@
 
             // Custom animations (will be populated by Python)
             { ANIMATION_CODE }
+            { ANIMATION_CODE }
 
             controls.update();
             renderer.render(scene, camera);
@@ -224,5 +251,6 @@
         animate();
     </script>
 </body>
+
 
 </html>

--- a/base/agent/base_solver.py
+++ b/base/agent/base_solver.py
@@ -10,6 +10,15 @@ from base.engine.logs import logger as _logger
 from base.env.base_env import SkinEnv
 from base.engine.logs import logger
 
+
+def _extract_agent_observation(rendered: Any) -> Any:
+    """Support both unified render output and legacy render_skin return values."""
+    if hasattr(rendered, "agent_view"):
+        return rendered.agent_view
+    if isinstance(rendered, dict) and "agent_view" in rendered:
+        return rendered.get("agent_view")
+    return rendered
+
 # Maximum number of past actions to retain; if None, retain all past actions
 MAX_PAST_ACTIONS = None
 
@@ -183,7 +192,11 @@ class SolverAgent(BaseAgent):
         events_count = {}
         
         raw_obs = env.observe_semantic()
-        agent_obs = env.render_skin(raw_obs)
+        if hasattr(env, "render"):
+            rendered = env.render(raw_obs)
+        else:
+            rendered = env.render_skin(raw_obs)
+        agent_obs = _extract_agent_observation(rendered)
         initial_observation = agent_obs
 
         while cur_steps < max_step and not env.done():
@@ -221,7 +234,7 @@ class SolverAgent(BaseAgent):
                 "parse_error": (action or {}).get("_parse_error"),
             })
             cur_reward += reward
-            agent_obs = info["skinned"]
+            agent_obs = info.get("agent_obs", info.get("skinned"))
             for e in info.get("events", []):
                 events_count[e] = events_count.get(e, 0) + 1
             cur_steps += 1

--- a/base/env/__init__.py
+++ b/base/env/__init__.py
@@ -1,1 +1,13 @@
 # Env subpackage
+
+from base.env.base_env import BaseEnv, ObsEnv, SkinEnv
+from base.env.base_observation import ObservationPolicy
+from base.env.skin_output import SkinRenderOutput
+
+__all__ = [
+    "BaseEnv",
+    "ObsEnv",
+    "SkinEnv",
+    "ObservationPolicy",
+    "SkinRenderOutput",
+]

--- a/base/env/base_env.py
+++ b/base/env/base_env.py
@@ -6,6 +6,7 @@
 from abc import ABC, abstractmethod
 from typing import Dict, Any, Optional, Tuple, List
 from base.env.base_observation import ObservationPolicy
+from base.env.skin_output import SkinRenderOutput
 
 class BaseEnv(ABC):
     """Defines the true state, transition, and reward."""
@@ -115,6 +116,25 @@ class SkinEnv(ObsEnv):
         """Render the final input from semantic observation."""
         pass
 
+    def render(self, omega) -> SkinRenderOutput:
+        """Unified render API with backward compatibility for legacy render_skin outputs."""
+        rendered = self.render_skin(omega)
+
+        if isinstance(rendered, SkinRenderOutput):
+            return rendered
+
+        if isinstance(rendered, dict) and "agent_view" in rendered:
+            return SkinRenderOutput(
+                agent_view=rendered.get("agent_view"),
+                human_view=rendered.get("human_view"),
+                modality=rendered.get("modality", "text"),
+                artifacts=rendered.get("artifacts", {}),
+                metadata=rendered.get("metadata", {}),
+            )
+
+        # Legacy path: string/dict/any returned from render_skin is treated as agent view.
+        return SkinRenderOutput(agent_view=rendered, modality="text")
+
     def done(self) -> bool:
         # Default: only step count; override/add conditions if needed
         return self._t >= self.configs["termination"]["max_steps"]
@@ -130,14 +150,20 @@ class SkinEnv(ObsEnv):
         reward, events, rinfo = self.reward(action)
         self._t += 1
         raw_obs = self.observe_semantic()
-        agent_obs = self.render_skin(raw_obs)
-        if_done = self.done(s_next)
+        rendered = self.render(raw_obs)
+        agent_obs = rendered.agent_view
+        try:
+            if_done = self.done(s_next)
+        except TypeError:
+            if_done = self.done()
         info = {
             "raw_obs": raw_obs,
             "skinned": agent_obs,
+            "agent_obs": agent_obs,
+            "human_view": rendered.resolved_human_view(),
+            "render_output": rendered.to_dict(),
             "events": events,
             "reward_info": rinfo,
             "last_action_result": self._last_action_result,
         }
         return s_next, reward, if_done, info
-

--- a/base/env/skin_output.py
+++ b/base/env/skin_output.py
@@ -1,0 +1,48 @@
+# ============================================================
+# SKIN RENDER OUTPUT CONTRACT
+# Purpose: Unified render output for text / 2D / 3D environment skins
+# ============================================================
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Literal
+
+SkinModality = Literal["text", "2d", "3d", "multi"]
+
+
+@dataclass
+class SkinRenderOutput:
+    """Normalized output contract for all skin renderers.
+
+    agent_view:
+        The content passed into the solver/agent.
+    human_view:
+        Optional richer view for UI or debugging. Defaults to agent_view.
+    modality:
+        Main modality used by this render output.
+    artifacts:
+        File paths / runtime handles (e.g. html entrypoint, model folder).
+    metadata:
+        Extra renderer metadata (camera settings, legend, etc.).
+    """
+
+    agent_view: Any
+    human_view: Any | None = None
+    modality: SkinModality = "text"
+    artifacts: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def resolved_human_view(self) -> Any:
+        if self.human_view is None:
+            return self.agent_view
+        return self.human_view
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "agent_view": self.agent_view,
+            "human_view": self.resolved_human_view(),
+            "modality": self.modality,
+            "artifacts": self.artifacts,
+            "metadata": self.metadata,
+        }

--- a/benchmarks/base/agent.py
+++ b/benchmarks/base/agent.py
@@ -17,6 +17,15 @@ from base.engine.logs import logger as _logger
 # Maximum number of past actions to retain; if None, retain all past actions
 MAX_PAST_ACTIONS = None
 
+
+def _extract_agent_observation(rendered: Any) -> Any:
+    """Support both unified render output and legacy render_skin return values."""
+    if hasattr(rendered, "agent_view"):
+        return rendered.agent_view
+    if isinstance(rendered, dict) and "agent_view" in rendered:
+        return rendered.get("agent_view")
+    return rendered
+
 class SolverAgent(BaseAgent):
     """
     Solver Agent is used to recive different environment desc and action space desc.
@@ -150,7 +159,11 @@ class SolverAgent(BaseAgent):
         events_count = {}
         
         raw_obs = env.observe_semantic()
-        agent_obs = env.render_skin(raw_obs)
+        if hasattr(env, "render"):
+            rendered = env.render(raw_obs)
+        else:
+            rendered = env.render_skin(raw_obs)
+        agent_obs = _extract_agent_observation(rendered)
         initial_observation = agent_obs
 
         while cur_steps < max_step and not env.done():
@@ -188,7 +201,7 @@ class SolverAgent(BaseAgent):
                 "parse_error": (action or {}).get("_parse_error"),
             })
             cur_reward += reward
-            agent_obs = info["skinned"]
+            agent_obs = info.get("agent_obs", info.get("skinned"))
             for e in info.get("events", []):
                 events_count[e] = events_count.get(e, 0) + 1
             cur_steps += 1

--- a/game_logic.js
+++ b/game_logic.js
@@ -1,0 +1,297 @@
+### INIT_GAME_CODE ###
+function initializeGame() {
+    console.log('Initializing game...');
+    
+    // Reset game state
+    gameState.selectedPiece = null;
+    gameState.puzzlePieces = [];
+    gameState.goalPlatforms = [];
+    gameState.platforms = [];
+    gameState.moveCount = 0;
+    
+    // Traverse the scene to identify and categorize objects
+    scene.traverse((object) => {
+        if (object.isMesh || object.isGroup) {
+            // Check for puzzle pieces (movable objects)
+            if (object.userData.isPuzzlePiece) {
+                gameState.puzzlePieces.push(object);
+                // Save original material for each mesh in the object
+                object.traverse((child) => {
+                    if (child.isMesh && child.material) {
+                        child.userData.originalMaterial = child.material;
+                    }
+                });
+                console.log('Found puzzle piece:', object.name);
+            }
+            
+            // Check for goal platforms (target locations)
+            if (object.userData.isGoalPlatform) {
+                gameState.goalPlatforms.push(object);
+                console.log('Found goal platform:', object.name);
+            }
+            
+            // Check for regular platforms
+            if (object.userData.isPlatform && !object.userData.isGoalPlatform) {
+                gameState.platforms.push(object);
+            }
+        }
+    });
+    
+    console.log(`Game initialized: ${gameState.puzzlePieces.length} puzzle pieces, ${gameState.goalPlatforms.length} goal platforms`);
+    
+    // Initial win check
+    checkWinCondition();
+}
+### END_INIT_GAME_CODE ###
+
+### HANDLE_KEYPRESS_CODE ###
+function handleKeyPress(key) {
+    key = key.toLowerCase();
+    
+    // ESC: Deselect current piece (FIRST priority)
+    if (key === 'escape') {
+        if (gameState.selectedPiece) {
+            deselectPiece();
+        }
+        return;
+    }
+    
+    // If no piece is selected, ignore other keys
+    if (!gameState.selectedPiece) {
+        if (key === 'r') {
+            // R without selection: restart level
+            restartLevel();
+        }
+        return;
+    }
+    
+    const piece = gameState.selectedPiece;
+    const gridSize = 2; // Grid alignment size
+    
+    // WASD/Arrow keys: Move selected piece on grid
+    if (key === 'w' || key === 'arrowup') {
+        piece.position.z -= gridSize;
+        gameState.moveCount++;
+    } else if (key === 's' || key === 'arrowdown') {
+        piece.position.z += gridSize;
+        gameState.moveCount++;
+    } else if (key === 'a' || key === 'arrowleft') {
+        piece.position.x -= gridSize;
+        gameState.moveCount++;
+    } else if (key === 'd' || key === 'arrowright') {
+        piece.position.x += gridSize;
+        gameState.moveCount++;
+    }
+    // Space: Snap to platform and deselect
+    else if (key === ' ' || key === 'space') {
+        snapToPlatform(piece);
+    }
+    // R: Rotate piece
+    else if (key === 'r') {
+        piece.rotation.y += Math.PI / 2;
+        gameState.moveCount++;
+    }
+    
+    // Update move counter display
+    updateMoveCounter();
+    
+    // Check win condition after movement
+    checkWinCondition();
+}
+### END_HANDLE_KEYPRESS_CODE ###
+
+### MOUSE_CLICK_CODE ###
+function onMouseClick(event) {
+    // Calculate mouse position in normalized device coordinates (-1 to +1)
+    const rect = renderer.domElement.getBoundingClientRect();
+    mouse.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+    mouse.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+    
+    // Update raycaster with camera and mouse position
+    raycaster.setFromCamera(mouse, camera);
+    
+    // Check for intersections with all objects in scene
+    const intersects = raycaster.intersectObjects(scene.children, true);
+    
+    if (intersects.length > 0) {
+        // Find the first intersected object that is a puzzle piece
+        for (let i = 0; i < intersects.length; i++) {
+            let clickedObject = intersects[i].object;
+            
+            // Traverse up to find the root puzzle piece
+            while (clickedObject.parent && !clickedObject.userData.isPuzzlePiece) {
+                clickedObject = clickedObject.parent;
+                if (clickedObject === scene) break;
+            }
+            
+            // If we found a puzzle piece, select it
+            if (clickedObject.userData.isPuzzlePiece) {
+                selectPiece(clickedObject);
+                return;
+            }
+        }
+    }
+    
+    // If clicked on empty space, deselect current piece
+    if (gameState.selectedPiece) {
+        deselectPiece();
+    }
+}
+### END_MOUSE_CLICK_CODE ###
+
+### HELPER_FUNCTIONS ###
+function selectPiece(clickedObject) {
+    // If clicking the same piece, deselect it
+    if (gameState.selectedPiece === clickedObject) {
+        deselectPiece();
+        return;
+    }
+    
+    // Deselect previous piece if any
+    if (gameState.selectedPiece) {
+        deselectPiece();
+    }
+    
+    // Select new piece
+    gameState.selectedPiece = clickedObject;
+    
+    // Highlight the selected piece
+    clickedObject.traverse((child) => {
+        if (child.isMesh && child.material) {
+            // Create highlight material
+            const highlightMaterial = child.material.clone();
+            highlightMaterial.emissive = new THREE.Color(0x00ffff);
+            highlightMaterial.emissiveIntensity = 0.5;
+            child.material = highlightMaterial;
+        }
+    });
+    
+    console.log('Selected piece:', clickedObject.name);
+}
+
+function deselectPiece() {
+    if (!gameState.selectedPiece) return;
+    
+    const piece = gameState.selectedPiece;
+    
+    // Restore original materials
+    piece.traverse((child) => {
+        if (child.isMesh && child.userData.originalMaterial) {
+            child.material = child.userData.originalMaterial;
+        }
+    });
+    
+    gameState.selectedPiece = null;
+    console.log('Deselected piece');
+}
+
+function snapToPlatform(piece) {
+    // Snap to grid alignment
+    piece.position.x = Math.round(piece.position.x / 2) * 2;
+    piece.position.z = Math.round(piece.position.z / 2) * 2;
+    
+    // Deselect the piece after snapping
+    deselectPiece();
+    
+    console.log('Snapped piece to grid');
+}
+
+function checkWinCondition() {
+    if (gameState.puzzlePieces.length === 0 || gameState.goalPlatforms.length === 0) {
+        return false;
+    }
+    
+    // Check if all puzzle pieces are on goal platforms
+    let piecesOnGoal = 0;
+    
+    for (const piece of gameState.puzzlePieces) {
+        for (const goal of gameState.goalPlatforms) {
+            const distance = piece.position.distanceTo(goal.position);
+            if (distance < 1.5) { // Tolerance for "on platform"
+                piecesOnGoal++;
+                break;
+            }
+        }
+    }
+    
+    // Win if all pieces are on goal platforms
+    if (piecesOnGoal === gameState.puzzlePieces.length) {
+        displayWinMessage();
+        return true;
+    }
+    
+    return false;
+}
+
+function displayWinMessage() {
+    console.log('🎉 Level Complete! Moves:', gameState.moveCount);
+    
+    // Create win message overlay
+    const winDiv = document.createElement('div');
+    winDiv.style.position = 'absolute';
+    winDiv.style.top = '50%';
+    winDiv.style.left = '50%';
+    winDiv.style.transform = 'translate(-50%, -50%)';
+    winDiv.style.padding = '30px';
+    winDiv.style.backgroundColor = 'rgba(45, 53, 97, 0.9)';
+    winDiv.style.color = '#FFD93D';
+    winDiv.style.fontSize = '32px';
+    winDiv.style.fontWeight = 'bold';
+    winDiv.style.borderRadius = '15px';
+    winDiv.style.textAlign = 'center';
+    winDiv.style.zIndex = '1000';
+    winDiv.innerHTML = `🎉 Level Complete! 🎉<br><span style="font-size: 20px;">Moves: ${gameState.moveCount}</span><br><span style="font-size: 16px;">Press R to restart</span>`;
+    winDiv.id = 'winMessage';
+    document.body.appendChild(winDiv);
+}
+
+function restartLevel() {
+    // Remove win message if present
+    const winMsg = document.getElementById('winMessage');
+    if (winMsg) {
+        winMsg.remove();
+    }
+    
+    // Reset puzzle pieces to original positions
+    gameState.puzzlePieces.forEach((piece) => {
+        if (piece.userData.originalPosition) {
+            piece.position.copy(piece.userData.originalPosition);
+            piece.rotation.copy(piece.userData.originalRotation || new THREE.Euler());
+        }
+    });
+    
+    // Deselect any selected piece
+    if (gameState.selectedPiece) {
+        deselectPiece();
+    }
+    
+    // Reset move counter
+    gameState.moveCount = 0;
+    updateMoveCounter();
+    
+    console.log('Level restarted');
+}
+
+function updateMoveCounter() {
+    // Update move counter display if it exists
+    const moveCounter = document.getElementById('moveCounter');
+    if (moveCounter) {
+        moveCounter.textContent = `Moves: ${gameState.moveCount}`;
+    }
+}
+
+// Save original positions of puzzle pieces on first initialization
+function saveOriginalPositions() {
+    gameState.puzzlePieces.forEach((piece) => {
+        if (!piece.userData.originalPosition) {
+            piece.userData.originalPosition = piece.position.clone();
+            piece.userData.originalRotation = piece.rotation.clone();
+        }
+    });
+}
+
+// Call this after initial game setup
+setTimeout(() => {
+    saveOriginalPositions();
+}, 100);
+### END_HELPER_FUNCTIONS ###

--- a/game_logic.txt
+++ b/game_logic.txt
@@ -1,0 +1,237 @@
+### INIT_GAME_CODE ###
+function initializeGame() {
+    // Initialize game state
+    gameState.puzzlePieces = [];
+    gameState.goalPlatforms = [];
+    gameState.regularPlatforms = [];
+    gameState.selectedPiece = null;
+    
+    // Traverse the scene to categorize objects
+    scene.traverse((object) => {
+        if (object.isMesh || object.isGroup) {
+            // Check for puzzle pieces (crates)
+            if (object.userData.isPuzzlePiece) {
+                gameState.puzzlePieces.push(object);
+                // Save original material for highlighting
+                if (object.material) {
+                    object.userData.originalMaterial = object.material;
+                }
+            }
+            
+            // Check for goal platforms (target zones)
+            if (object.userData.isGoalPlatform) {
+                gameState.goalPlatforms.push(object);
+                if (object.material) {
+                    object.userData.originalMaterial = object.material;
+                }
+            }
+            
+            // Check for regular platforms (floor tiles)
+            if (object.userData.isPlatform && !object.userData.isGoalPlatform) {
+                gameState.regularPlatforms.push(object);
+            }
+        }
+    });
+    
+    console.log('Game initialized:', {
+        puzzlePieces: gameState.puzzlePieces.length,
+        goalPlatforms: gameState.goalPlatforms.length,
+        regularPlatforms: gameState.regularPlatforms.length
+    });
+}
+### END_INIT_GAME_CODE ###
+
+### HANDLE_KEYPRESS_CODE ###
+function handleKeyPress(key) {
+    // ESC: Deselect current piece (handle FIRST)
+    if (key === 'Escape') {
+        if (gameState.selectedPiece) {
+            // Restore original material
+            if (gameState.selectedPiece.userData.originalMaterial) {
+                gameState.selectedPiece.material = gameState.selectedPiece.userData.originalMaterial;
+            }
+            gameState.selectedPiece = null;
+        }
+        return;
+    }
+    
+    // If no piece is selected, ignore movement keys
+    if (!gameState.selectedPiece) {
+        if (key === 'r' || key === 'R') {
+            // R without selection: Restart level
+            location.reload();
+        }
+        return;
+    }
+    
+    const gridSize = 2;
+    let moved = false;
+    
+    // WASD/Arrow keys: Move selected piece on grid
+    if (key === 'w' || key === 'ArrowUp') {
+        gameState.selectedPiece.position.z -= gridSize;
+        moved = true;
+    } else if (key === 's' || key === 'ArrowDown') {
+        gameState.selectedPiece.position.z += gridSize;
+        moved = true;
+    } else if (key === 'a' || key === 'ArrowLeft') {
+        gameState.selectedPiece.position.x -= gridSize;
+        moved = true;
+    } else if (key === 'd' || key === 'ArrowRight') {
+        gameState.selectedPiece.position.x += gridSize;
+        moved = true;
+    } 
+    // Space: Snap to platform and deselect
+    else if (key === ' ' || key === 'Spacebar') {
+        snapToPlatform(gameState.selectedPiece);
+        return;
+    }
+    // R: Rotate piece
+    else if (key === 'r' || key === 'R') {
+        gameState.selectedPiece.rotation.y += Math.PI / 2;
+    }
+    
+    // After movement, snap to grid
+    if (moved) {
+        gameState.selectedPiece.position.x = Math.round(gameState.selectedPiece.position.x / gridSize) * gridSize;
+        gameState.selectedPiece.position.z = Math.round(gameState.selectedPiece.position.z / gridSize) * gridSize;
+    }
+}
+### END_HANDLE_KEYPRESS_CODE ###
+
+### MOUSE_CLICK_CODE ###
+function onMouseClick(event) {
+    // Calculate mouse position in normalized device coordinates
+    const mouse = new THREE.Vector2();
+    mouse.x = (event.clientX / window.innerWidth) * 2 - 1;
+    mouse.y = -(event.clientY / window.innerHeight) * 2 + 1;
+    
+    // Update the raycaster
+    raycaster.setFromCamera(mouse, camera);
+    
+    // Find intersected objects
+    const intersects = raycaster.intersectObjects(scene.children, true);
+    
+    if (intersects.length > 0) {
+        let clickedObject = intersects[0].object;
+        
+        // Traverse up to find the root object with userData
+        while (clickedObject.parent && !clickedObject.userData.isPuzzlePiece) {
+            clickedObject = clickedObject.parent;
+            if (clickedObject === scene) break;
+        }
+        
+        // If we found a puzzle piece, select it
+        if (clickedObject.userData.isPuzzlePiece) {
+            selectPiece(clickedObject);
+        } else {
+            // Clicked elsewhere, deselect
+            if (gameState.selectedPiece) {
+                if (gameState.selectedPiece.userData.originalMaterial) {
+                    gameState.selectedPiece.material = gameState.selectedPiece.userData.originalMaterial;
+                }
+                gameState.selectedPiece = null;
+            }
+        }
+    }
+}
+### END_MOUSE_CLICK_CODE ###
+
+### HELPER_FUNCTIONS ###
+function selectPiece(clickedObject) {
+    // If clicking the same piece, deselect it
+    if (gameState.selectedPiece === clickedObject) {
+        if (gameState.selectedPiece.userData.originalMaterial) {
+            gameState.selectedPiece.material = gameState.selectedPiece.userData.originalMaterial;
+        }
+        gameState.selectedPiece = null;
+        return;
+    }
+    
+    // Deselect previous piece
+    if (gameState.selectedPiece) {
+        if (gameState.selectedPiece.userData.originalMaterial) {
+            gameState.selectedPiece.material = gameState.selectedPiece.userData.originalMaterial;
+        }
+    }
+    
+    // Select new piece
+    gameState.selectedPiece = clickedObject;
+    
+    // Highlight the selected piece
+    if (clickedObject.material) {
+        // Save original material if not already saved
+        if (!clickedObject.userData.originalMaterial) {
+            clickedObject.userData.originalMaterial = clickedObject.material;
+        }
+        
+        // Create highlight material
+        const highlightMaterial = new THREE.MeshStandardMaterial({
+            color: 0x00ff00,
+            emissive: 0x00ff00,
+            emissiveIntensity: 0.3,
+            metalness: 0.5,
+            roughness: 0.5
+        });
+        
+        clickedObject.material = highlightMaterial;
+    }
+}
+
+function snapToPlatform(piece) {
+    if (!piece) return;
+    
+    const gridSize = 2;
+    
+    // Snap position to grid
+    piece.position.x = Math.round(piece.position.x / gridSize) * gridSize;
+    piece.position.z = Math.round(piece.position.z / gridSize) * gridSize;
+    
+    // Restore original material
+    if (piece.userData.originalMaterial) {
+        piece.material = piece.userData.originalMaterial;
+    }
+    
+    // Deselect piece
+    gameState.selectedPiece = null;
+    
+    // Check win condition
+    checkWinCondition();
+}
+
+function checkWinCondition() {
+    if (gameState.puzzlePieces.length === 0 || gameState.goalPlatforms.length === 0) {
+        return;
+    }
+    
+    let piecesOnGoals = 0;
+    const threshold = 0.5; // Distance threshold for snapping
+    
+    // Check each puzzle piece
+    for (const piece of gameState.puzzlePieces) {
+        let onGoal = false;
+        
+        // Check against each goal platform
+        for (const goal of gameState.goalPlatforms) {
+            const dx = Math.abs(piece.position.x - goal.position.x);
+            const dz = Math.abs(piece.position.z - goal.position.z);
+            
+            if (dx < threshold && dz < threshold) {
+                onGoal = true;
+                break;
+            }
+        }
+        
+        if (onGoal) {
+            piecesOnGoals++;
+        }
+    }
+    
+    // Win condition: all pieces on goal platforms
+    if (piecesOnGoals === gameState.puzzlePieces.length) {
+        setTimeout(() => {
+            alert('Congratulations! You solved the puzzle!');
+        }, 100);
+    }
+}
+### END_HELPER_FUNCTIONS ###

--- a/run_skin_generation.py
+++ b/run_skin_generation.py
@@ -24,6 +24,9 @@ Usage:
 
 import argparse
 import asyncio
+import json
+import logging
+from logging.handlers import RotatingFileHandler
 import time
 from datetime import datetime
 from pathlib import Path
@@ -31,9 +34,12 @@ from pathlib import Path
 import yaml
 
 from autoenv.pipeline import VisualPipeline
+from autoenv.pipeline.visual.nodes import ThreeJSAssemblyNode, AutoEnvContext
 from base.engine.cost_monitor import CostMonitor
 
 DEFAULT_CONFIG = "config/env_skin_gen.yaml"
+
+logger = logging.getLogger("skin_gen")
 
 
 def load_config(path: str) -> dict:
@@ -41,6 +47,158 @@ def load_config(path: str) -> dict:
     if not p.exists():
         return {}
     return yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+
+
+async def test_prompt_mode(
+    input_path: Path,
+    output_dir: Path,
+    model: str,
+    image_model: str,
+    requirements: str = "",
+    envs_root_path: str = "",
+):
+    """Test ThreeJSAssemblyNode enhancement prompt with existing .glb files.
+    
+    Args:
+        input_path: Directory containing models_3d/ folder with .glb files
+        output_dir: Output directory for the test
+        model: LLM model name
+        image_model: Image model name (unused in test mode)
+        requirements: User requirements/instruction text
+        envs_root_path: Root path for environments
+    """
+    logger.info("🧪 TEST PROMPT MODE: Testing ThreeJSAssemblyNode enhancement prompt")
+    
+    # Create timestamped output directory
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    test_output_dir = output_dir / f"test_prompt_{ts}"
+    test_output_dir.mkdir(parents=True, exist_ok=True)
+    
+    # Reconfigure logger to write to the new timestamped directory
+    log_file = test_output_dir / "log.txt"
+    
+    # Remove old handlers and add new ones pointing to the timestamped log
+    for handler in logger.handlers[:]:
+        logger.removeHandler(handler)
+    
+    handlers = [
+        logging.StreamHandler(),
+        RotatingFileHandler(log_file, maxBytes=5_000_000, backupCount=3, encoding="utf-8"),
+    ]
+    logger.handlers = handlers
+    for handler in handlers:
+        handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
+    
+    # Log configuration parameters
+    logger.info("=" * 60)
+    logger.info("TEST PROMPT MODE CONFIGURATION")
+    logger.info("=" * 60)
+    logger.info(f"Requirements: {requirements if requirements else '(Not provided)'}")
+    logger.info(f"Envs Root Path: {envs_root_path if envs_root_path else '(Not provided)'}")
+    logger.info(f"Input Path: {input_path}")
+    logger.info(f"Model: {model}")
+    logger.info(f"Output Directory: {test_output_dir}")
+    logger.info("=" * 60)
+    logger.info("")
+    
+    # Verify input_path exists
+    if not input_path.exists():
+        logger.error(f"❌ input_path not found: {input_path}")
+        return
+    
+    # Check for models_3d directory with .glb files
+    models_dir = input_path / "models_3d"
+    if not models_dir.exists():
+        logger.error(f"❌ models_3d directory not found: {models_dir}")
+        return
+    
+    glb_files = list(models_dir.glob("*.glb"))
+    if not glb_files:
+        logger.error(f"❌ No .glb files found in {models_dir}")
+        return
+    
+    logger.info(f"✓ Found {len(glb_files)} .glb files in {models_dir}")
+    
+    # Create output game directory
+    game_dir = test_output_dir / "game"
+    game_dir.mkdir(parents=True, exist_ok=True)
+    
+    # Copy models_3d to game/models
+    import shutil
+    models_dst = game_dir / "models"
+    if models_dst.exists():
+        shutil.rmtree(models_dst)
+    shutil.copytree(models_dir, models_dst)
+    logger.info(f"✓ Copied models to {models_dst}")
+    
+    # Try to load strategy.json from input_path
+    strategy = {}
+    strategy_file = input_path / "strategy.json"
+    if strategy_file.exists():
+        with open(strategy_file, encoding="utf-8") as f:
+            strategy = json.load(f)
+        logger.info(f"✓ Loaded strategy from {strategy_file}")
+    else:
+        # Create minimal strategy if not found
+        strategy = {
+            "rendering_approach": {"type": "grid_3d"},
+            "style_anchor": glb_files[0].stem,
+            "assets": [
+                {
+                    "id": glb_file.stem,
+                    "name": glb_file.stem,
+                    "type": "game_object",
+                    "priority": 10
+                }
+                for glb_file in glb_files
+            ]
+        }
+        logger.info(f"⚠️  No strategy.json found, created minimal strategy for {len(glb_files)} models")
+    
+    # Create context with models_3d
+    ctx = AutoEnvContext(
+        output_dir=test_output_dir,
+        strategy=strategy,
+        models_3d={
+            glb_file.stem: {
+                "path": f"models/{glb_file.name}",
+                "asset_id": glb_file.stem
+            }
+            for glb_file in glb_files
+        }
+    )
+    
+    logger.info(f"🔨 Creating ThreeJSAssemblyNode with model: {model}")
+    
+    # Initialize ThreeJSAssemblyNode with agent
+    from autoenv.miniswe_agent import MiniSWEAutoEnvAgent
+    
+    # Create MiniSWE agent for enhancement
+    agent = MiniSWEAutoEnvAgent(
+        llm_name=model,
+        mode="yolo",
+        step_limit=60,
+        cost_limit=12.0,
+        environment_type="local",
+        cwd=str(Path.cwd()),
+    )
+    
+    node = ThreeJSAssemblyNode(agent=agent)
+    
+    # Execute node
+    logger.info("⚡ Running ThreeJSAssemblyNode...")
+    try:
+        await node.execute(ctx)
+        if ctx.success:
+            logger.info(f"✅ Test complete! Generated: {ctx.game_file}")
+            logger.info(f"📁 Game directory: {game_dir}")
+            logger.info("📝 Enhancement prompt was sent to LLM for testing")
+        else:
+            logger.error(f"❌ Node execution failed: {ctx.error}")
+    except Exception as e:
+        logger.error(f"❌ Error during node execution: {e}")
+        import traceback
+        logger.error(traceback.format_exc())
 
 
 async def run_skin_gen(
@@ -64,7 +222,7 @@ async def run_skin_gen(
         meshy_config: Meshy API configuration for 3D mode
     """
     if not exist_env_path and not instruction:
-        print("❌ Provide either 'exist_environment_path' or 'requirements'")
+        logger.error("❌ Provide either 'exist_environment_path' or 'requirements'")
         return
 
     # Timing
@@ -83,11 +241,11 @@ async def run_skin_gen(
     visual_output.mkdir(parents=True, exist_ok=True)
 
     # Create pipeline with dimension support
-    print(f"🎮 [{label}] Generating {dimension.upper()} scene...")
+    logger.info(f"🎮 [{label}] Generating {dimension.upper()} scene...")
     
     # Validate Meshy config for 3D mode
     if dimension == "3d" and (not meshy_config or not meshy_config.get("api_key")):
-        print("❌ 3D mode requires Meshy API key. Set 'meshy.api_key' in config.")
+        logger.error("❌ 3D mode requires Meshy API key. Set 'meshy.api_key' in config.")
         return
     
     # Create unified pipeline
@@ -111,16 +269,16 @@ async def run_skin_gen(
     elapsed = time.time() - start_time
 
     if ctx.success:
-        print(f"✅ [{label}] Generation complete → {visual_output}")
-        print(f"⏱️  Total time: {elapsed:.1f}s")
+        logger.info(f"✅ [{label}] Generation complete → {visual_output}")
+        logger.info(f"⏱️  Total time: {elapsed:.1f}s")
         
         # Show 3D model info if available
         if dimension == "3d" and hasattr(ctx, "models_3d") and ctx.models_3d:
-            print(f"🧊 3D Models generated: {len(ctx.models_3d)}")
+            logger.info(f"🧊 3D Models generated: {len(ctx.models_3d)}")
             for model_id, info in ctx.models_3d.items():
-                print(f"   - {model_id}: {info.get('path')}")
+                logger.info(f"   - {model_id}: {info.get('path')}")
     else:
-        print(f"❌ [{label}] Generation failed: {ctx.error}")
+        logger.error(f"❌ [{label}] Generation failed: {ctx.error}")
 
 
 async def main():
@@ -131,6 +289,7 @@ async def main():
     parser.add_argument("--model", help="Override: LLM model name")
     parser.add_argument("--image-model", help="Override: image model name")
     parser.add_argument("--output", help="Override: output directory")
+    parser.add_argument("--input-path", help="Test mode: path with .glb files to test ThreeJSAssemblyNode")
     
     # 3D generation options
     parser.add_argument("--3d", dest="enable_3d", action="store_true",
@@ -151,6 +310,67 @@ async def main():
     output = args.output or cfg.get("envs_root_path") or "workspace/envs"
     exist_env_path = args.env or cfg.get("exist_environment_path")
     instruction = args.instruction or cfg.get("requirements")
+    input_path = args.input_path or cfg.get("input_path")
+    
+    output_dir = Path(output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Configure logging: console + rotating file in envs_root_path/log.txt
+    # NOTE: test_prompt_mode will reconfigure logging for timestamped directory
+    log_file = output_dir / "log.txt"
+    handlers = [
+        logging.StreamHandler(),
+        RotatingFileHandler(log_file, maxBytes=5_000_000, backupCount=3, encoding="utf-8"),
+    ]
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=handlers,
+    )
+
+    # ===== TEST PROMPT MODE =====
+    if input_path:
+        input_path_obj = Path(input_path).expanduser().resolve()
+        # Check if it has .glb files
+        models_dir = input_path_obj / "models_3d"
+        has_glb = models_dir.exists() and any(models_dir.glob("*.glb"))
+        
+        if has_glb:
+            logger.info("🧪 TEST PROMPT MODE DETECTED")
+            logger.info(f"📁 Input path: {input_path_obj}")
+            logger.info(f"🤖 Model: {model}")
+            
+            with CostMonitor() as monitor:
+                await test_prompt_mode(
+                    input_path=input_path_obj,
+                    output_dir=output_dir,
+                    model=model,
+                    image_model=image_model,
+                    requirements=instruction or "",
+                    envs_root_path=output,
+                )
+                
+                # Print cost summary
+                summary = monitor.summary()
+                if summary["call_count"] > 0:
+                    logger.info("\n" + "=" * 50)
+                    logger.info("💰 Test Prompt Cost Summary")
+                    logger.info("=" * 50)
+                    logger.info(f"Total Cost: ${summary['total_cost']:.4f}")
+                    logger.info(f"Total Calls: {summary['call_count']}")
+                    logger.info(f"Input Tokens: {summary['total_input_tokens']:,}")
+                    logger.info(f"Output Tokens: {summary['total_output_tokens']:,}")
+                    
+                    if summary["by_model"]:
+                        logger.info("\nBy Model:")
+                        for model_name, stats in summary["by_model"].items():
+                            logger.info(f"  {model_name}: ${stats['cost']:.4f} ({stats['calls']} calls)")
+                    
+                    cost_file = monitor.save()
+                    logger.info(f"\n📊 Cost saved: {cost_file}")
+            return
+    
+    # ===== NORMAL PIPELINE MODE =====
     
     # Determine dimension (CLI takes priority)
     if args.enable_3d:
@@ -168,30 +388,27 @@ async def main():
         meshy_config["max_assets"] = args.max_3d_assets
 
     if not image_model:
-        print("❌ No image_model configured. Set 'image_model' in config or --image-model")
+        logger.error("❌ No image_model configured. Set 'image_model' in config or --image-model")
         return
 
     # Validate exist_env_path if provided
     if exist_env_path:
         exist_env_path = Path(exist_env_path)
         if not exist_env_path.exists():
-            print(f"❌ Environment path not found: {exist_env_path}")
+            logger.error(f"❌ Environment path not found: {exist_env_path}")
             return
 
-    output_dir = Path(output)
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    print(f"🔧 Config: {args.config}")
-    print(f"🤖 Model: {model}")
-    print(f"🎨 Image Model: {image_model}")
-    print(f"📁 Output: {output}")
-    print(f"📐 Dimension: {dimension.upper()}")
+    logger.info(f"🔧 Config: {args.config}")
+    logger.info(f"🤖 Model: {model}")
+    logger.info(f"🎨 Image Model: {image_model}")
+    logger.info(f"📁 Output: {output}")
+    logger.info(f"📐 Dimension: {dimension.upper()}")
     if dimension == "3d":
-        print(f"🧊 Meshy API: {meshy_config.get('base_url', 'https://api.meshy.ai/v1')}")
+        logger.info(f"🧊 Meshy API: {meshy_config.get('base_url', 'https://api.meshy.ai/v1')}")
     if exist_env_path:
-        print(f"📂 Environment: {exist_env_path}")
+        logger.info(f"📂 Environment: {exist_env_path}")
     if instruction:
-        print(f"📝 Instruction: {instruction[:50]}...")
+        logger.info(f"📝 Instruction: {instruction[:50]}...")
 
     with CostMonitor() as monitor:
         await run_skin_gen(
@@ -206,21 +423,21 @@ async def main():
 
         # Print and save cost summary
         summary = monitor.summary()
-        print("\n" + "=" * 50)
-        print("💰 Cost Summary")
-        print("=" * 50)
-        print(f"Total Cost: ${summary['total_cost']:.4f}")
-        print(f"Total Calls: {summary['call_count']}")
-        print(f"Input Tokens: {summary['total_input_tokens']:,}")
-        print(f"Output Tokens: {summary['total_output_tokens']:,}")
+        logger.info("\n" + "=" * 50)
+        logger.info("💰 Cost Summary")
+        logger.info("=" * 50)
+        logger.info(f"Total Cost: ${summary['total_cost']:.4f}")
+        logger.info(f"Total Calls: {summary['call_count']}")
+        logger.info(f"Input Tokens: {summary['total_input_tokens']:,}")
+        logger.info(f"Output Tokens: {summary['total_output_tokens']:,}")
 
         if summary["by_model"]:
-            print("\nBy Model:")
+            logger.info("\nBy Model:")
             for model_name, stats in summary["by_model"].items():
-                print(f"  {model_name}: ${stats['cost']:.4f} ({stats['calls']} calls)")
+                logger.info(f"  {model_name}: ${stats['cost']:.4f} ({stats['calls']} calls)")
 
         cost_file = monitor.save()
-        print(f"\n📊 Cost saved: {cost_file}")
+        logger.info(f"\n📊 Cost saved: {cost_file}")
 
 
 if __name__ == "__main__":

--- a/run_skin_generation.py
+++ b/run_skin_generation.py
@@ -271,6 +271,9 @@ async def run_skin_gen(
     if ctx.success:
         logger.info(f"✅ [{label}] Generation complete → {visual_output}")
         logger.info(f"⏱️  Total time: {elapsed:.1f}s")
+        if getattr(ctx, "skin_manifest", None):
+            manifest = ctx.skin_manifest
+            logger.info(f"🧾 Skin manifest: modality={manifest.get('modality')} entrypoint={manifest.get('entrypoint')}")
         
         # Show 3D model info if available
         if dimension == "3d" and hasattr(ctx, "models_3d") and ctx.models_3d:
@@ -442,4 +445,3 @@ async def main():
 
 if __name__ == "__main__":
     asyncio.run(main())
-

--- a/tests/test_skin_output_contract.py
+++ b/tests/test_skin_output_contract.py
@@ -1,0 +1,96 @@
+from typing import Any, Dict, List, Optional, Tuple
+
+from base.agent.base_solver import _extract_agent_observation
+from base.env.base_env import SkinEnv
+from base.env.base_observation import ObservationPolicy
+from base.env.skin_output import SkinRenderOutput
+
+
+class DummyObservationPolicy(ObservationPolicy):
+    def __call__(self, env_state: Dict[str, Any], t: int):
+        return {"value": env_state["value"], "t": t}
+
+
+class LegacyRenderEnv(SkinEnv):
+    def __init__(self):
+        super().__init__(env_id=1, obs_policy=DummyObservationPolicy())
+
+    def _dsl_config(self):
+        self.configs = {"termination": {"max_steps": 5}}
+
+    def reset(self, mode: str = "load", world_id: Optional[str] = None, seed: Optional[int] = None):
+        self._state = {"value": 0}
+        self._history = []
+        self._t = 0
+        return self._state
+
+    def _load_world(self, world_id: str) -> Dict[str, Any]:
+        return {"value": 0}
+
+    def _generate_world(self, seed: Optional[int] = None) -> str:
+        return "dummy"
+
+    def transition(self, action: Dict[str, Any]) -> Dict[str, Any]:
+        self._state = {"value": self._state["value"] + 1}
+        return self._state
+
+    def reward(self, action: Dict[str, Any]) -> Tuple[float, List[str], Dict[str, Any]]:
+        return 0.0, [], {}
+
+    def observe_semantic(self):
+        return self.obs_policy(self._state, self._t)
+
+    def render_skin(self, omega) -> Any:
+        return f"value={omega['value']}"
+
+
+class StructuredRenderEnv(LegacyRenderEnv):
+    def render_skin(self, omega) -> Any:
+        return {
+            "agent_view": {"compact": omega["value"]},
+            "human_view": f"Value is {omega['value']}",
+            "modality": "3d",
+            "artifacts": {"entrypoint": "game/index.html"},
+            "metadata": {"camera": "orbit"},
+        }
+
+
+class DoneNoArgEnv(LegacyRenderEnv):
+    # Validate compatibility path where done() takes no state argument.
+    def done(self) -> bool:
+        return self._t >= 1
+
+
+def test_legacy_render_skin_is_normalized():
+    env = LegacyRenderEnv()
+    env.reset()
+    _, _, _, info = env.step({"action": "noop", "params": {}})
+
+    assert info["skinned"] == "value=1"
+    assert info["agent_obs"] == "value=1"
+    assert info["human_view"] == "value=1"
+    assert info["render_output"]["modality"] == "text"
+
+
+def test_structured_render_skin_contract_is_preserved():
+    env = StructuredRenderEnv()
+    env.reset()
+    _, _, _, info = env.step({"action": "noop", "params": {}})
+
+    assert info["agent_obs"] == {"compact": 1}
+    assert info["skinned"] == {"compact": 1}
+    assert info["human_view"] == "Value is 1"
+    assert info["render_output"]["modality"] == "3d"
+    assert info["render_output"]["artifacts"]["entrypoint"] == "game/index.html"
+
+
+def test_step_done_signature_compatibility():
+    env = DoneNoArgEnv()
+    env.reset()
+    _, _, done, _ = env.step({"action": "noop", "params": {}})
+    assert done is True
+
+
+def test_solver_extracts_agent_view_from_contract_object():
+    rendered = SkinRenderOutput(agent_view={"v": 1}, modality="text")
+    assert _extract_agent_observation(rendered) == {"v": 1}


### PR DESCRIPTION
## Summary
- add a unified skin render output contract (`SkinRenderOutput`) for text/2D/3D
- keep backward compatibility with existing `render_skin()` env implementations
- update solver paths to consume `agent_obs` with legacy fallback to `skinned`
- emit unified `skin_manifest` in visual pipeline for both 2D and 3D outputs
- add AGENTS.md documenting 3D build flow and abstraction alignment
- add compatibility tests for legacy/structured render outputs

## Why
PR #8 adds 3D scene generation, but the runtime contracts across modalities were not explicit.
This patch aligns text/2D/3D under one skin abstraction while preserving current benchmark behavior.

## Validation
- `PYTHONPATH=. pytest -q tests/test_skin_output_contract.py` (4 passed)
- `PYTHONPATH=. python -m compileall ...` on touched modules

## Notes
- Full `pytest` still has an existing baseline collection failure in `benchmarks/33_AlienDecision/test_fixed_rewards.py` due cwd-relative `./config.yaml`.
